### PR TITLE
Number Slider UI Elements

### DIFF
--- a/FGEGraphics/ClientSystem/ViewUI2D.cs
+++ b/FGEGraphics/ClientSystem/ViewUI2D.cs
@@ -197,14 +197,6 @@ public class ViewUI2D
         finally
         {
             StackNoteHelper.Pop();
-            Internal.RenderStack.Reverse();
-            int mouseX = (int)Client.MouseX, mouseY = (int)Client.MouseY;
-            bool mouseDown = Client.CurrentMouse.IsButtonDown(MouseButton.Left);
-            foreach (UIElement elem in Internal.RenderStack)
-            {
-                elem.TickInteraction(mouseX, mouseY, mouseDown);
-            }
-            Internal.MousePreviouslyDown = mouseDown;
         }
     }
 
@@ -212,14 +204,16 @@ public class ViewUI2D
     public void Tick()
     {
         CurrentScreen.FullTick(Client.Delta);
-        // TODO: why isn't this running??
-        /*Internal.RenderStack.Reverse();
+        Internal.RenderStack.Reverse();
         int mouseX = (int)Client.MouseX, mouseY = (int)Client.MouseY;
         bool mouseDown = Client.CurrentMouse.IsButtonDown(MouseButton.Left);
         foreach (UIElement elem in Internal.RenderStack)
         {
-            elem.TickInteraction(mouseX, mouseY, mouseDown);
+            if (elem.IsValid)
+            {
+                elem.TickInteraction(mouseX, mouseY, mouseDown);
+            } 
         }
-        Internal.MousePreviouslyDown = mouseDown;*/
+        Internal.MousePreviouslyDown = mouseDown;
     }
 }

--- a/FGEGraphics/UISystem/TextAlignment.cs
+++ b/FGEGraphics/UISystem/TextAlignment.cs
@@ -14,6 +14,7 @@ using System.Threading.Tasks;
 
 namespace FGEGraphics.UISystem;
 
+// TODO: Replace this with a *draw* anchor point system in UIPositionHelper.
 /// <summary>Simple enumeration of text alignment modes.</summary>
 public enum TextAlignment
 {

--- a/FGEGraphics/UISystem/UIBox.cs
+++ b/FGEGraphics/UISystem/UIBox.cs
@@ -26,7 +26,8 @@ namespace FGEGraphics.UISystem;
 /// <param name="style">The style of the element.</param>
 /// <param name="pos">The position of the element.</param>
 /// <param name="shouldRender">Whether the element should render automatically.</param>
-public class UIBox(UIElementStyle style, UIPositionHelper pos, bool shouldRender = true) : UIElement(pos, shouldRender)
+/// <param name="enabled">Whether the element can be interacted with.</param>
+public class UIBox(UIElementStyle style, UIPositionHelper pos, bool shouldRender = true, bool enabled = true) : UIElement(pos, shouldRender, enabled)
 {
     /// <summary>The style of the box.</summary>
     public override UIElementStyle Style { get; } = style;

--- a/FGEGraphics/UISystem/UIButton.cs
+++ b/FGEGraphics/UISystem/UIButton.cs
@@ -36,12 +36,9 @@ public class UIButton : UIClickableElement
     /// <summary>Constructs a new style-based button.</summary>
     /// <param name="text">The text to display.</param>
     /// <param name="clicked">The action to run when clicked.</param>
-    /// <param name="normal">The style to display when neither hovered nor clicked.</param>
-    /// <param name="hover">The style to display when hovered.</param>
-    /// <param name="click">The style to display when clicked.</param>
+    /// <param name="styles">The clickable styles.</param>
     /// <param name="pos">The position of the element.</param>
-    public UIButton(string text, Action clicked, UIElementStyle normal, UIElementStyle hover, UIElementStyle click, UIPositionHelper pos)
-        : base(normal, hover, click, pos, false, clicked)
+    public UIButton(string text, Action clicked, StyleGroup styles, UIPositionHelper pos) : base(styles, pos, false, clicked)
     {
         AddChild(Box = new UIBox(UIElementStyle.Empty, pos.AtOrigin(), false));
         Text = new(this, text, horizontalAlignment: TextAlignment.CENTER, verticalAlignment: TextAlignment.CENTER);
@@ -56,10 +53,11 @@ public class UIButton : UIClickableElement
     /// <param name="pos">The position of the element.</param>
     public static UIButton Textured(string text, TextureEngine textures, string textureSet, Action clicked, UIElementStyle style, UIPositionHelper pos)
     {
+        // TODO: Move this to a method on UIClickableElement.StyleGroup
         UIElementStyle normal = new(style) { BaseTexture = textures.GetTexture($"{textureSet}_none") };
         UIElementStyle hover = new(style) { BaseTexture = textures.GetTexture($"{textureSet}_hover") };
         UIElementStyle click = new(style) { BaseTexture = textures.GetTexture($"{textureSet}_click") };
-        return new UIButton(text, clicked, normal, hover, click, pos);
+        return new UIButton(text, clicked, new(normal, hover, click), pos);
     }
 
     /// <summary>Renders this button on the screen.</summary>

--- a/FGEGraphics/UISystem/UIButton.cs
+++ b/FGEGraphics/UISystem/UIButton.cs
@@ -40,7 +40,7 @@ public class UIButton : UIClickableElement
     /// <param name="pos">The position of the element.</param>
     public UIButton(string text, Action clicked, StyleGroup styles, UIPositionHelper pos) : base(styles, pos, false, clicked)
     {
-        AddChild(Box = new UIBox(UIElementStyle.Empty, pos.AtOrigin(), false));
+        AddChild(Box = new UIBox(UIElementStyle.Empty, pos.AtOrigin(), false, false));
         Text = new(this, text, horizontalAlignment: TextAlignment.CENTER, verticalAlignment: TextAlignment.CENTER);
     }
 

--- a/FGEGraphics/UISystem/UICheckbox.cs
+++ b/FGEGraphics/UISystem/UICheckbox.cs
@@ -32,19 +32,17 @@ public class UICheckbox : UIElement
     /// <summary>Constructs a new button-based checkbox.</summary>
     /// <param name="text">The text to display.</param>
     /// <param name="label">The text label style.</param>
-    /// <param name="normal">The style to display when neither hovered nor clicked.</param>
-    /// <param name="hover">The style to display when hovered.</param>
-    /// <param name="click">The style to display when clicked.</param>
+    /// <param name="styles">The clickable styles.</param>
     /// <param name="pos">The position of the element.</param>
-    public UICheckbox(string text, UIElementStyle label, UIElementStyle normal, UIElementStyle hover, UIElementStyle click, UIPositionHelper pos) : base(pos)
+    public UICheckbox(string text, UIElementStyle label, UIClickableElement.StyleGroup styles, UIPositionHelper pos) : base(pos)
     {
-        AddChild(Button = new UIButton(null, Toggle, normal, hover, click, pos.AtOrigin()));
+        AddChild(Button = new UIButton(null, Toggle, styles, pos.AtOrigin()));
         AddChild(Label = new UILabel(text, label, pos.AtOrigin().ConstantWidth(-1)));
         Label.Position.GetterXY(() => Label.Text.GetPosition(X + Width + 10, Y + Height / 2));
     }
 
     /// <summary>Constructs a new checkbox using the normal button style as the label style.</summary>
-    public UICheckbox(string text, UIElementStyle normal, UIElementStyle hover, UIElementStyle click, UIPositionHelper pos) : this(text, new(normal) { BaseColor = Color4F.Transparent }, normal, hover, click, pos)
+    public UICheckbox(string text, UIClickableElement.StyleGroup styles, UIPositionHelper pos) : this(text, new(styles.Normal) { BaseColor = Color4F.Transparent }, styles, pos)
     {
     }
 

--- a/FGEGraphics/UISystem/UIClickableElement.cs
+++ b/FGEGraphics/UISystem/UIClickableElement.cs
@@ -10,28 +10,37 @@ namespace FGEGraphics.UISystem;
 /// <summary>Represents a styled clickable UI element on the screen.</summary>
 public abstract class UIClickableElement : UIElement
 {
-    /// <summary>The render style to use when the element is not being interacted with.</summary>
-    public UIElementStyle StyleNormal;
+    /// <summary>Grouped styles for a <see cref="UIClickableElement"/>.</summary>
+    /// <param name="normal"></param>
+    /// <param name="hover"></param>
+    /// <param name="click"></param>
+    public class StyleGroup(UIElementStyle normal, UIElementStyle hover, UIElementStyle click)
+    {
+        /// <summary>The render style to use when the element is not being interacted with.</summary>
+        public UIElementStyle Normal = normal;
 
-    /// <summary>The render style to use when the user is hovering their mouse cursor over this element.</summary>
-    public UIElementStyle StyleHover;
+        /// <summary>The render style to use when the user is hovering their mouse cursor over this element.</summary>
+        public UIElementStyle Hover = hover;
 
-    /// <summary>The render style to use when the user is clicking on this element.</summary>
-    public UIElementStyle StyleClick;
+        /// <summary>The render style to use when the user is clicking on this element.</summary>
+        public UIElementStyle Click = click;
+    }
+
+    /// <summary>The clickable style group.</summary>
+    public StyleGroup Styles;
 
     /// <summary>Constructs the styled clickable element.</summary>
-    /// <param name="normal">The style to display when neither hovered nor clicked.</param>
-    /// <param name="hover">The style to display when hovered.</param>
-    /// <param name="click">The style to display when clicked.</param>
+    /// <param name="styles">The clickable styles.</param>
     /// <param name="pos">The position of the element.</param>
     /// <param name="requireText">Whether the styles must support text rendering.</param>
     /// <param name="onClick">Ran when the element is clicked.</param>
-    public UIClickableElement(UIElementStyle normal, UIElementStyle hover, UIElementStyle click, UIPositionHelper pos, bool requireText = false, Action onClick = null) : base(pos)
+    public UIClickableElement(StyleGroup styles, UIPositionHelper pos, bool requireText = false, Action onClick = null) : base(pos)
     {
         Clicked += onClick;
-        StyleNormal = AddStyle(normal, requireText);
-        StyleHover = AddStyle(hover, requireText);
-        StyleClick = AddStyle(click, requireText);
+        Styles = styles;
+        AddStyle(Styles.Normal, requireText);
+        AddStyle(Styles.Hover, requireText);
+        AddStyle(Styles.Click, requireText);
     }
 
     /// <summary>Returns the normal, hover, or click style based on the current element state.</summary>
@@ -41,13 +50,13 @@ public abstract class UIClickableElement : UIElement
         {
             if (Pressed)
             {
-                return StyleClick;
+                return Styles.Click;
             }
             if (Hovered)
             {
-                return StyleHover;
+                return Styles.Hover;
             }
-            return StyleNormal;
+            return Styles.Normal;
         }
     }
 }

--- a/FGEGraphics/UISystem/UIClickableElement.cs
+++ b/FGEGraphics/UISystem/UIClickableElement.cs
@@ -11,9 +11,9 @@ namespace FGEGraphics.UISystem;
 public abstract class UIClickableElement : UIElement
 {
     /// <summary>Grouped styles for a <see cref="UIClickableElement"/>.</summary>
-    /// <param name="normal"></param>
-    /// <param name="hover"></param>
-    /// <param name="click"></param>
+    /// <param name="normal">The default style to use.</param>
+    /// <param name="hover">The style to use on hover.</param>
+    /// <param name="click">The style to use on click.</param>
     public class StyleGroup(UIElementStyle normal, UIElementStyle hover, UIElementStyle click)
     {
         /// <summary>The render style to use when the element is not being interacted with.</summary>

--- a/FGEGraphics/UISystem/UIElement.cs
+++ b/FGEGraphics/UISystem/UIElement.cs
@@ -367,11 +367,11 @@ public abstract class UIElement
         if (ElementInternal.HoverInternal && !(mouseDown && Position.View.InteractingElement == this))
         {
             ElementInternal.HoverInternal = false;
-            Position.View.InteractingElement = null;
             if (Enabled)
             {
                 Hovered = false;
                 Pressed = false;
+                Position.View.InteractingElement = null;
             }
             if (Position.View.Internal.MousePreviouslyDown)
             {

--- a/FGEGraphics/UISystem/UIElement.cs
+++ b/FGEGraphics/UISystem/UIElement.cs
@@ -530,7 +530,7 @@ public abstract class UIElement
     /// <param name="y">The Y position of the mouse.</param>
     public void MouseLeftUpOutside(int x, int y)
     {
-        MouseLeftUp();
+        MouseLeftUpOutside();
         foreach (UIElement child in GetChildrenAt(x, y))
         {
             child.MouseLeftUpOutside(x, y);

--- a/FGEGraphics/UISystem/UIElement.cs
+++ b/FGEGraphics/UISystem/UIElement.cs
@@ -230,7 +230,7 @@ public abstract class UIElement
         public List<UIElementText> Texts = [];
 
         /// <summary>The current style of this element.</summary>
-        public UIElementStyle CurrentStyle;
+        public UIElementStyle CurrentStyle = UIElementStyle.Empty;
     }
 
     /// <summary>Data internal to a <see cref="UIElement"/> instance.</summary>
@@ -430,13 +430,14 @@ public abstract class UIElement
     /// <summary>Updates the current style and fires relevant events if it has changed.</summary>
     public void UpdateStyle()
     {
-        if (Style != ElementInternal.CurrentStyle)
+        UIElementStyle newStyle = Style ?? UIElementStyle.Empty;
+        if (newStyle != ElementInternal.CurrentStyle)
         {
             if (ElementInternal.CurrentStyle is not null)
             {
                 SwitchFromStyle(ElementInternal.CurrentStyle);
             }
-            SwitchToStyle(ElementInternal.CurrentStyle = Style);
+            SwitchToStyle(ElementInternal.CurrentStyle = newStyle);
         }
     }
 

--- a/FGEGraphics/UISystem/UIElement.cs
+++ b/FGEGraphics/UISystem/UIElement.cs
@@ -344,10 +344,10 @@ public abstract class UIElement
                 }
                 else if (!mDown && ElementInternal.MousePreviouslyDown)
                 {
-                    if (element.Enabled && element.Clicked is not null)
+                    if (element.Enabled)
                     {
                         element.Pressed = false;
-                        element.Clicked();
+                        element.Clicked?.Invoke();
                     }
                     element.MouseLeftUp(mX, mY);
                 }

--- a/FGEGraphics/UISystem/UIElement.cs
+++ b/FGEGraphics/UISystem/UIElement.cs
@@ -531,7 +531,7 @@ public abstract class UIElement
     public void MouseLeftUpOutside(int x, int y)
     {
         MouseLeftUpOutside();
-        foreach (UIElement child in GetChildrenAt(x, y))
+        foreach (UIElement child in GetChildrenNotAt(x, y))
         {
             child.MouseLeftUpOutside(x, y);
         }

--- a/FGEGraphics/UISystem/UIElementText.cs
+++ b/FGEGraphics/UISystem/UIElementText.cs
@@ -159,7 +159,7 @@ public class UIElementText
     public int Width => Renderable?.Width ?? 0;
 
     /// <summary>The total height of the text.</summary>
-    public int Height => Renderable?.Lines.Length * Internal.ParentElement.ElementInternal.CurrentStyle.TextFont.FontDefault.Height ?? 0;
+    public int Height => Renderable?.Lines?.Length * Internal.ParentElement.ElementInternal.CurrentStyle.TextFont?.FontDefault.Height ?? 0;
 
     /// <summary>Returns the render position of the text given a starting position.</summary>
     /// <param name="startX">The left-oriented anchor X value.</param>

--- a/FGEGraphics/UISystem/UIElementText.cs
+++ b/FGEGraphics/UISystem/UIElementText.cs
@@ -148,6 +148,7 @@ public class UIElementText
         }
     }
 
+    // TODO: make these not NPE when empty
     /// <summary>
     /// The <see cref="RenderableText"/> object corresponding to the parent element's current style.
     /// If <see cref="UIElementStyle.CanRenderText(UIElementText)"/> returns false, this returns <see cref="RenderableText.Empty"/>.

--- a/FGEGraphics/UISystem/UIGroup.cs
+++ b/FGEGraphics/UISystem/UIGroup.cs
@@ -17,6 +17,6 @@ namespace FGEGraphics.UISystem;
 /// <summary>Represents a simple container of several UI elements.</summary>
 /// <remarks>Constructs a new group.</remarks>
 /// <param name="pos">The position of the element.</param>
-public class UIGroup(UIPositionHelper pos) : UIElement(pos)
+public class UIGroup(UIPositionHelper pos) : UIElement(pos, enabled: false)
 {
 }

--- a/FGEGraphics/UISystem/UILabel.cs
+++ b/FGEGraphics/UISystem/UILabel.cs
@@ -42,10 +42,9 @@ public class UILabel : UIElement
     {
         Style = AddStyle(style, true);
         Text = new(this, text, true, Position.Width);
+        UpdateStyle();
+        Position.GetterWidthHeight(() => Text.Width, () => Text.Height);
     }
-
-    /// <summary>Fixes this label's width and height based on <see cref="Text"/> and <see cref="Style"/>.</summary>
-    public override void SwitchToStyle(UIElementStyle style) => Position.ConstantWidthHeight(Text.Renderable.Width, Text.Renderable.Lines.Length * style.TextFont.FontDefault.Height);
 
     /// <summary>Renders this label on the screen.</summary>
     /// <param name="view">The UI view.</param>

--- a/FGEGraphics/UISystem/UILabeledNumberSlider.cs
+++ b/FGEGraphics/UISystem/UILabeledNumberSlider.cs
@@ -14,15 +14,32 @@ using System.Threading.Tasks;
 
 namespace FGEGraphics.UISystem;
 
+/// <summary>
+/// Represents a <see cref="UINumberSlider"/> element with an editable number
+/// label alongside the interactable area.
+/// </summary>
 public class UILabeledNumberSlider : UINumberSlider
 {
+    /// <summary>The slider's value label.</summary>
+    // TODO: Make editable
     public UILabel Label;
 
+    /// <summary>Constructs a labeled number slider.</summary>
+    /// <param name="min">The minimum slider value.</param>
+    /// <param name="max">The maximum slider value.</param>
+    /// <param name="initial">The initial slider value.</param>
+    /// <param name="isInt">Whether to use integers instead of decimals.</param>
+    /// <param name="sliderStyles">The slider styles.</param>
+    /// <param name="labelLeft">Whether the label should be on the left of the slider.</param>
+    /// <param name="labelPadding">The horizontal spacing between the label and the slider.</param>
+    /// <param name="labelStyle">The label style.</param>
+    /// <param name="pos">The position of the slider.</param>
     public UILabeledNumberSlider(double min, double max, double initial, bool isInt, StyleGroup sliderStyles, bool labelLeft, int labelPadding, UIElementStyle labelStyle, UIPositionHelper pos) : base(min, max, initial, isInt, sliderStyles, pos)
     {
         AddStyle(labelStyle, true);
         AddChild(Label = new UILabel(string.Empty, labelStyle, pos.AtOrigin()));
         // FIXME: Using labelLeft, when dimensions change, pos not updated until one frame later
+        // (This won't be an issue with the TextAlignment replacement in UIPositionHelper, presumably)
         Label.Position.GetterXY(() => labelLeft ? -labelPadding - Label.Width : pos.Width + labelPadding, () => (pos.Height - Label.Height) / 2);
     }
 

--- a/FGEGraphics/UISystem/UILabeledNumberSlider.cs
+++ b/FGEGraphics/UISystem/UILabeledNumberSlider.cs
@@ -28,13 +28,14 @@ public class UILabeledNumberSlider : UINumberSlider
     /// <param name="min">The minimum slider value.</param>
     /// <param name="max">The maximum slider value.</param>
     /// <param name="initial">The initial slider value.</param>
-    /// <param name="isInt">Whether to use integers instead of decimals.</param>
+    /// <param name="interval">The grid-snapping interval, if any.</param>
+    /// <param name="integral">Whether to use integers instead of decimals.</param>
     /// <param name="sliderStyles">The slider styles.</param>
     /// <param name="labelLeft">Whether the label should be on the left of the slider.</param>
     /// <param name="labelPadding">The horizontal spacing between the label and the slider.</param>
     /// <param name="labelStyle">The label style.</param>
     /// <param name="pos">The position of the slider.</param>
-    public UILabeledNumberSlider(double min, double max, double initial, bool isInt, StyleGroup sliderStyles, bool labelLeft, int labelPadding, UIElementStyle labelStyle, UIPositionHelper pos) : base(min, max, initial, isInt, sliderStyles, pos)
+    public UILabeledNumberSlider(double min, double max, double initial, double interval, bool integral, StyleGroup sliderStyles, bool labelLeft, int labelPadding, UIElementStyle labelStyle, UIPositionHelper pos) : base(min, max, initial, interval, integral, sliderStyles, pos)
     {
         AddStyle(labelStyle, true);
         AddChild(Label = new UILabel(string.Empty, labelStyle, pos.AtOrigin()));
@@ -47,6 +48,6 @@ public class UILabeledNumberSlider : UINumberSlider
     public override void Tick(double delta)
     {
         base.Tick(delta);
-        Label.Text.Content = IsInt ? $"{(int)Value}" : $"{Value:0.0}";
+        Label.Text.Content = Integral ? $"{(int)Value}" : $"{Value:0.0}";
     }
 }

--- a/FGEGraphics/UISystem/UILabeledNumberSlider.cs
+++ b/FGEGraphics/UISystem/UILabeledNumberSlider.cs
@@ -47,6 +47,6 @@ public class UILabeledNumberSlider : UINumberSlider
     public override void Tick(double delta)
     {
         base.Tick(delta);
-        Label.Text.Content = $"{Value:0.0}";
+        Label.Text.Content = IsInt ? $"{(int)Value}" : $"{Value:0.0}";
     }
 }

--- a/FGEGraphics/UISystem/UILabeledNumberSlider.cs
+++ b/FGEGraphics/UISystem/UILabeledNumberSlider.cs
@@ -1,0 +1,34 @@
+﻿//
+// This file is part of the game Voxalia, created by Frenetic LLC.
+// This code is Copyright (C) Frenetic LLC under the terms of a strict license.
+// See README.md or LICENSE.txt in the Voxalia source root for the contents of the license.
+// If neither of these are available, assume that neither you nor anyone other than the copyright holder
+// hold any right or permission to use this software until such time as the official license is identified.
+//
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace FGEGraphics.UISystem;
+
+public class UILabeledNumberSlider : UINumberSlider
+{
+    public UILabel Label;
+
+    public UILabeledNumberSlider(double min, double max, double initial, bool isInt, StyleGroup sliderStyles, bool labelLeft, int labelPadding, UIElementStyle labelStyle, UIPositionHelper pos) : base(min, max, initial, isInt, sliderStyles, pos)
+    {
+        AddStyle(labelStyle, true);
+        AddChild(Label = new UILabel(string.Empty, labelStyle, pos.AtOrigin().ConstantX(labelLeft ? -labelPadding : pos.Width + labelPadding)));
+        Label.Position.GetterY(() => (pos.Height - Label.Height) / 2);
+    }
+
+    /// <inheritdoc/>
+    public override void Tick(double delta)
+    {
+        base.Tick(delta);
+        Label.Text.Content = $"{Value:0.0}";
+    }
+}

--- a/FGEGraphics/UISystem/UILabeledNumberSlider.cs
+++ b/FGEGraphics/UISystem/UILabeledNumberSlider.cs
@@ -14,10 +14,7 @@ using System.Threading.Tasks;
 
 namespace FGEGraphics.UISystem;
 
-/// <summary>
-/// Represents a <see cref="UINumberSlider"/> element with an editable number
-/// label alongside the interactable area.
-/// </summary>
+/// <summary>Represents a <see cref="UINumberSlider"/> element with an editable number label alongside the interactable area.</summary>
 public class UILabeledNumberSlider : UINumberSlider
 {
     /// <summary>The slider's value label.</summary>

--- a/FGEGraphics/UISystem/UILabeledNumberSlider.cs
+++ b/FGEGraphics/UISystem/UILabeledNumberSlider.cs
@@ -48,6 +48,6 @@ public class UILabeledNumberSlider : UINumberSlider
     public override void Tick(double delta)
     {
         base.Tick(delta);
-        Label.Text.Content = Integral ? $"{(int)Value}" : $"{Value:0.0}";
+        Label.Text.Content = Integer ? $"{(int)Value}" : $"{Value:0.0}";
     }
 }

--- a/FGEGraphics/UISystem/UILabeledNumberSlider.cs
+++ b/FGEGraphics/UISystem/UILabeledNumberSlider.cs
@@ -21,8 +21,9 @@ public class UILabeledNumberSlider : UINumberSlider
     public UILabeledNumberSlider(double min, double max, double initial, bool isInt, StyleGroup sliderStyles, bool labelLeft, int labelPadding, UIElementStyle labelStyle, UIPositionHelper pos) : base(min, max, initial, isInt, sliderStyles, pos)
     {
         AddStyle(labelStyle, true);
-        AddChild(Label = new UILabel(string.Empty, labelStyle, pos.AtOrigin().ConstantX(labelLeft ? -labelPadding : pos.Width + labelPadding)));
-        Label.Position.GetterY(() => (pos.Height - Label.Height) / 2);
+        AddChild(Label = new UILabel(string.Empty, labelStyle, pos.AtOrigin()));
+        // FIXME: Using labelLeft, when dimensions change, pos not updated until one frame later
+        Label.Position.GetterXY(() => labelLeft ? -labelPadding - Label.Width : pos.Width + labelPadding, () => (pos.Height - Label.Height) / 2);
     }
 
     /// <inheritdoc/>

--- a/FGEGraphics/UISystem/UINativeTexture.cs
+++ b/FGEGraphics/UISystem/UINativeTexture.cs
@@ -24,7 +24,8 @@ namespace FGEGraphics.UISystem;
 /// <param name="texture">The texture to display.</param>
 /// <param name="pos">The position of the element.</param>
 /// <param name="shouldRender">Whether the element should render automatically.</param>
-public class UINativeTexture(Func<int> texture, UIPositionHelper pos, bool shouldRender = true) : UIElement(pos, shouldRender)
+/// <param name="enabled">Whether the element can be interacted with.</param>
+public class UINativeTexture(Func<int> texture, UIPositionHelper pos, bool shouldRender = true, bool enabled = true) : UIElement(pos, shouldRender, enabled)
 {
     /// <summary>The texture to display.</summary>
     public Func<int> Texture = texture;

--- a/FGEGraphics/UISystem/UINumberSlider.cs
+++ b/FGEGraphics/UISystem/UINumberSlider.cs
@@ -17,27 +17,41 @@ using FGEGraphics.GraphicsHelpers;
 
 namespace FGEGraphics.UISystem;
 
+/// <summary>The options for a <see cref="UINumberSlider"/> or <see cref="UILabeledNumberSlider"/>.</summary>
+/// <param name="min">The minimum slider value.</param>
+/// <param name="max">The maximum slider value.</param>
+/// <param name="initial">The initial slider value.</param>
+/// <param name="intMode">Whether to use an integer grid instead of decimals.</param>
+public struct UINumberSliderOptions(double min, double max, double initial, bool intMode)
+{
+    /// <summary>The minimum slider value.</summary>
+    public double Min = min;
+
+    /// <summary>The maximum slider value.</summary>
+    public double Max = max;
+
+    /// <summary>The initial slider value.</summary>
+    public double Initial = initial;
+
+    /// <summary>Whether to use an integer grid instead of decimals.</summary>
+    // TODO: Implement
+    public bool IntMode = intMode;
+}
+
 /// <summary>
 /// Represents a slider element that can choose between a range of real number values.
 /// For a labeled number slider, use <see cref="UILabeledNumberSlider"/>.
 /// </summary>
 public class UINumberSlider : UIClickableElement
 {
-    /// <summary>Whether the number slider uses integers instead of decimal numbers.</summary>
-    // TODO: Implement
-    public bool IntMode;
-
-    /// <summary>The minimum slider value.</summary>
-    public double Min = 0.0;
-
-    /// <summary>The maximum slider value.</summary>
-    public double Max = 10.0;
+    /// <summary>The slider options.</summary>
+    public UINumberSliderOptions Options;
 
     /// <summary>The current slider value.</summary>
-    public double Value = 0.0;
+    public double Value;
 
     /// <summary>The current slider progress (<c>0.0</c> to <c>1.0</c>).</summary>
-    public double Progress = 0.0;
+    public double Progress;
 
     /// <summary>
     /// The box placed at the current slider progress.
@@ -45,10 +59,15 @@ public class UINumberSlider : UIClickableElement
     /// </summary>
     public UIBox Button;
 
-    public UINumberSlider(UIElementStyle normal, UIElementStyle hover, UIElementStyle click, UIPositionHelper pos) : base(normal, hover, click, pos, false, null)
+    /// <summary>Constructs a number slider.</summary>
+    /// <param name="options">The slider options.</param>
+    /// <param name="styles">The clickable styles.</param>
+    /// <param name="pos">The position of the element.</param>
+    public UINumberSlider(UINumberSliderOptions options, StyleGroup styles, UIPositionHelper pos) : base(styles, pos, false, null)
     {
-        Progress = (Value - Min) / (Max - Min);
-        AddChild(Button = new(normal, pos.AtOrigin().ConstantWidth(pos.Height / 2), false));
+        Options = options;
+        Progress = (Options.Initial - Options.Min) / (Options.Max - Options.Min);
+        AddChild(Button = new(UIElementStyle.Empty, pos.AtOrigin().ConstantWidth(pos.Height / 2), false));
         TickButton();
     }
 
@@ -61,7 +80,7 @@ public class UINumberSlider : UIClickableElement
         if (Pressed)
         {
             Progress = Math.Clamp((Window.MouseX - X) / Width, 0.0, 1.0);
-            Value = Progress * (Max - Min) + Min;
+            Value = Progress * (Options.Max - Options.Min) + Options.Min;
             TickButton();
         }
         base.Tick(delta);
@@ -71,7 +90,7 @@ public class UINumberSlider : UIClickableElement
     public override void Render(ViewUI2D view, double delta, UIElementStyle style)
     {
         Engine.Textures.White.Bind();
-        Renderer2D.SetColor(StyleNormal.BorderColor);
+        Renderer2D.SetColor(Styles.Normal.BorderColor);
         view.Rendering.RenderRectangle(view.UIContext, X, Y + Height / 2 - style.BorderThickness / 2, X + Width, Y + Height / 2 + style.BorderThickness / 2);
         Renderer2D.SetColor(Color4F.White);
         Button.Render(view, delta, style);

--- a/FGEGraphics/UISystem/UINumberSlider.cs
+++ b/FGEGraphics/UISystem/UINumberSlider.cs
@@ -71,7 +71,10 @@ public class UINumberSlider : UIClickableElement
             Max = Min + Interval * maxStep;
         }
         Value = Math.Clamp(Integer ? (int)initial : initial, Min, Max);
-        AddChild(Button = new(UIElementStyle.Empty, pos.AtOrigin().ConstantWidth(pos.Height / 2), false));
+        AddChild(Button = new(UIElementStyle.Empty, pos.AtOrigin().ConstantWidth(pos.Height / 2), false)
+        {
+            Enabled = false
+        });
         Button.Position.GetterX(() => (int)(Progress * Width) - Button.Width / 2);
     }
 

--- a/FGEGraphics/UISystem/UINumberSlider.cs
+++ b/FGEGraphics/UISystem/UINumberSlider.cs
@@ -71,10 +71,7 @@ public class UINumberSlider : UIClickableElement
             Max = Min + Interval * maxStep;
         }
         Value = Math.Clamp(Integer ? (int)initial : initial, Min, Max);
-        AddChild(Button = new(UIElementStyle.Empty, pos.AtOrigin().ConstantWidth(pos.Height / 2), false)
-        {
-            Enabled = false
-        });
+        AddChild(Button = new(UIElementStyle.Empty, pos.AtOrigin().ConstantWidth(pos.Height / 2), false, false));
         Button.Position.GetterX(() => (int)(Progress * Width) - Button.Width / 2);
     }
 

--- a/FGEGraphics/UISystem/UINumberSlider.cs
+++ b/FGEGraphics/UISystem/UINumberSlider.cs
@@ -1,0 +1,79 @@
+﻿//
+// This file is part of the game Voxalia, created by Frenetic LLC.
+// This code is Copyright (C) Frenetic LLC under the terms of a strict license.
+// See README.md or LICENSE.txt in the Voxalia source root for the contents of the license.
+// If neither of these are available, assume that neither you nor anyone other than the copyright holder
+// hold any right or permission to use this software until such time as the official license is identified.
+//
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using FGECore.MathHelpers;
+using FGEGraphics.ClientSystem;
+using FGEGraphics.GraphicsHelpers;
+
+namespace FGEGraphics.UISystem;
+
+/// <summary>
+/// Represents a slider element that can choose between a range of real number values.
+/// For a labeled number slider, use <see cref="UILabeledNumberSlider"/>.
+/// </summary>
+public class UINumberSlider : UIClickableElement
+{
+    /// <summary>Whether the number slider uses integers instead of decimal numbers.</summary>
+    // TODO: Implement
+    public bool IntMode;
+
+    /// <summary>The minimum slider value.</summary>
+    public double Min = 0.0;
+
+    /// <summary>The maximum slider value.</summary>
+    public double Max = 10.0;
+
+    /// <summary>The current slider value.</summary>
+    public double Value = 0.0;
+
+    /// <summary>The current slider progress (<c>0.0</c> to <c>1.0</c>).</summary>
+    public double Progress = 0.0;
+
+    /// <summary>
+    /// The box placed at the current slider progress.
+    /// Not actually a <see cref="UIButton"/> for better UX.
+    /// </summary>
+    public UIBox Button;
+
+    public UINumberSlider(UIElementStyle normal, UIElementStyle hover, UIElementStyle click, UIPositionHelper pos) : base(normal, hover, click, pos, false, null)
+    {
+        Progress = (Value - Min) / (Max - Min);
+        AddChild(Button = new(normal, pos.AtOrigin().ConstantWidth(pos.Height / 2), false));
+        TickButton();
+    }
+
+    /// <summary>Fixes the <see cref="Button"/>'s position in accordance to the <see cref="Progress"/> value.</summary>
+    public void TickButton() => Button.Position.ConstantX((int)(Progress * Width) - Button.Width / 2);
+
+    /// <inheritdoc/>
+    public override void Tick(double delta)
+    {
+        if (Pressed)
+        {
+            Progress = Math.Clamp((Window.MouseX - X) / Width, 0.0, 1.0);
+            Value = Progress * (Max - Min) + Min;
+            TickButton();
+        }
+        base.Tick(delta);
+    }
+
+    /// <inheritdoc/>
+    public override void Render(ViewUI2D view, double delta, UIElementStyle style)
+    {
+        Engine.Textures.White.Bind();
+        Renderer2D.SetColor(StyleNormal.BorderColor);
+        view.Rendering.RenderRectangle(view.UIContext, X, Y + Height / 2 - style.BorderThickness / 2, X + Width, Y + Height / 2 + style.BorderThickness / 2);
+        Renderer2D.SetColor(Color4F.White);
+        Button.Render(view, delta, style);
+    }
+}

--- a/FGEGraphics/UISystem/UINumberSlider.cs
+++ b/FGEGraphics/UISystem/UINumberSlider.cs
@@ -14,6 +14,7 @@ using System.Threading.Tasks;
 using FGECore.MathHelpers;
 using FGEGraphics.ClientSystem;
 using FGEGraphics.GraphicsHelpers;
+using OpenTK.Windowing.GraphicsLibraryFramework;
 
 namespace FGEGraphics.UISystem;
 
@@ -29,14 +30,26 @@ public class UINumberSlider : UIClickableElement
     /// <summary>The maximum slider value.</summary>
     public double Max;
 
-    /// <summary>Whether to use an integer grid instead of decimals.</summary>
-    public bool IsInt;
+    /// <summary>
+    /// The grid-snapping interval. 
+    /// Set to <c>0.0</c> or less for a gridless slider.
+    /// </summary>
+    public double Interval;
+
+    /// <summary>
+    /// Whether the slider should use integers instead of decimals.
+    /// If true, <see cref="Interval"/> should be <c>1.0</c>.
+    /// </summary>
+    public bool Integral;
 
     /// <summary>The current slider value.</summary>
     public double Value;
 
     /// <summary>The current slider progress (<c>0.0</c> to <c>1.0</c>).</summary>
     public double Progress => (Value - Min) / (Max - Min);
+
+    /// <summary>Whether the slider snaps to a grid.</summary>
+    public bool UseInterval => Interval > 0.0;
 
     /// <summary>
     /// The box placed at the current slider progress.
@@ -45,18 +58,25 @@ public class UINumberSlider : UIClickableElement
     public UIBox Button;
 
     /// <summary>Constructs a number slider.</summary>
-    /// <param name="isInt">Whether to use integers instead of decimals.</param>
     /// <param name="min">The minimum slider value.</param>
     /// <param name="max">The maximum slider value.</param>
     /// <param name="initial">The initial slider value.</param>
+    /// <param name="interval">The grid-snapping interval, if any.</param>
+    /// <param name="integral">Whether to use integers instead of decimals.</param>
     /// <param name="styles">The clickable styles.</param>
     /// <param name="pos">The position of the element.</param>
-    public UINumberSlider(double min, double max, double initial, bool isInt, StyleGroup styles, UIPositionHelper pos) : base(styles, pos, false, null)
+    public UINumberSlider(double min, double max, double initial, double interval, bool integral, StyleGroup styles, UIPositionHelper pos) : base(styles, pos, false, null)
     {
-        Min = min;
-        Max = max;
-        IsInt = isInt;
-        Value = IsInt ? (int)initial : initial;
+        Integral = integral;
+        Interval = Integral ? 1.0 : interval;
+        Min = Integral ? (int)min : min;
+        Max = Integral ? (int)max : max;
+        if (UseInterval)
+        {
+            int maxStep = (int)((Max - Min) / Interval);
+            Max = Min + Interval * maxStep;
+        }
+        Value = Math.Clamp(Integral ? (int)initial : initial, Min, Max);
         AddChild(Button = new(UIElementStyle.Empty, pos.AtOrigin().ConstantWidth(pos.Height / 2), false));
         Button.Position.GetterX(() => (int)(Progress * Width) - Button.Width / 2);
     }
@@ -70,9 +90,12 @@ public class UINumberSlider : UIClickableElement
             return;
         }
         Value = Math.Clamp((Window.MouseX - X) / Width, 0.0, 1.0) * (Max - Min) + Min;
-        if (IsInt)
+        if (Integral || (UseInterval && !Window.Window.KeyboardState.IsKeyDown(Keys.LeftShift))) // TODO: Better way?
         {
-            Value = Math.Round(Value);
+            int step = (int)Math.Round((Value - Min) / Interval);
+            double lower = Min + Interval * step;
+            double higher = Min + Interval * (step + 1);
+            Value = (Value - lower) <= (higher - Value) ? lower : higher;
         }
     }
 
@@ -84,13 +107,13 @@ public class UINumberSlider : UIClickableElement
         int lineWidth = style.BorderThickness / 2;
         int centerY = Y + Height / 2;
         view.Rendering.RenderRectangle(view.UIContext, X, centerY - lineWidth, X + Width, centerY + lineWidth);
-        if (IsInt)
+        if (UseInterval)
         {
-            int values = (int)(Max - Min);
-            int spacing = Width / values;
-            for (int i = 0; i < values + 1; i++)
+            double values = (Max - Min) / Interval;
+            double spacing = Width / values;
+            for (int i = 0; i < (int)values + 1; i++)
             {
-                int x = X + i * spacing;
+                int x = (int)(X + i * spacing);
                 int height = Height / 6; // TODO: Make this value customizable
                 view.Rendering.RenderRectangle(view.UIContext, x - lineWidth, centerY - height, x + lineWidth, centerY + height);
             }

--- a/FGEGraphics/UISystem/UINumberSlider.cs
+++ b/FGEGraphics/UISystem/UINumberSlider.cs
@@ -17,35 +17,21 @@ using FGEGraphics.GraphicsHelpers;
 
 namespace FGEGraphics.UISystem;
 
-/// <summary>The options for a <see cref="UINumberSlider"/> or <see cref="UILabeledNumberSlider"/>.</summary>
-/// <param name="min">The minimum slider value.</param>
-/// <param name="max">The maximum slider value.</param>
-/// <param name="initial">The initial slider value.</param>
-/// <param name="intMode">Whether to use an integer grid instead of decimals.</param>
-public struct UINumberSliderOptions(double min, double max, double initial, bool intMode)
-{
-    /// <summary>The minimum slider value.</summary>
-    public double Min = min;
-
-    /// <summary>The maximum slider value.</summary>
-    public double Max = max;
-
-    /// <summary>The initial slider value.</summary>
-    public double Initial = initial;
-
-    /// <summary>Whether to use an integer grid instead of decimals.</summary>
-    // TODO: Implement
-    public bool IntMode = intMode;
-}
-
 /// <summary>
 /// Represents a slider element that can choose between a range of real number values.
 /// For a labeled number slider, use <see cref="UILabeledNumberSlider"/>.
 /// </summary>
 public class UINumberSlider : UIClickableElement
 {
-    /// <summary>The slider options.</summary>
-    public UINumberSliderOptions Options;
+    /// <summary>The minimum slider value.</summary>
+    public double Min;
+
+    /// <summary>The maximum slider value.</summary>
+    public double Max;
+
+    /// <summary>Whether to use an integer grid instead of decimals.</summary>
+    // TODO: Implement
+    public bool IsInt;
 
     /// <summary>The current slider value.</summary>
     public double Value;
@@ -60,30 +46,33 @@ public class UINumberSlider : UIClickableElement
     public UIBox Button;
 
     /// <summary>Constructs a number slider.</summary>
-    /// <param name="options">The slider options.</param>
+    /// <param name="min">The minimum slider value.</param>
+    /// <param name="max">The maximum slider value.</param>
+    /// <param name="initial">The initial slider value.</param>
+    /// <param name="isInt">Whether to use integers instead of decimals.</param>
     /// <param name="styles">The clickable styles.</param>
     /// <param name="pos">The position of the element.</param>
-    public UINumberSlider(UINumberSliderOptions options, StyleGroup styles, UIPositionHelper pos) : base(styles, pos, false, null)
+    public UINumberSlider(double min, double max, double initial, bool isInt, StyleGroup styles, UIPositionHelper pos) : base(styles, pos, false, null)
     {
-        Options = options;
-        Progress = (Options.Initial - Options.Min) / (Options.Max - Options.Min);
+        Min = min;
+        Max = max;
+        Value = initial;
+        IsInt = isInt;
+        Progress = (Value - Min) / (Max - Min);
         AddChild(Button = new(UIElementStyle.Empty, pos.AtOrigin().ConstantWidth(pos.Height / 2), false));
-        TickButton();
+        Button.Position.GetterX(() => (int)(Progress * Width) - Button.Width / 2);
     }
-
-    /// <summary>Fixes the <see cref="Button"/>'s position in accordance to the <see cref="Progress"/> value.</summary>
-    public void TickButton() => Button.Position.ConstantX((int)(Progress * Width) - Button.Width / 2);
 
     /// <inheritdoc/>
     public override void Tick(double delta)
     {
-        if (Pressed)
-        {
-            Progress = Math.Clamp((Window.MouseX - X) / Width, 0.0, 1.0);
-            Value = Progress * (Options.Max - Options.Min) + Options.Min;
-            TickButton();
-        }
         base.Tick(delta);
+        if (!Pressed)
+        {
+            return;
+        }
+        Progress = Math.Clamp((Window.MouseX - X) / Width, 0.0, 1.0);
+        Value = Progress * (Max - Min) + Min;
     }
 
     /// <inheritdoc/>

--- a/FGEGraphics/UISystem/UIScreen.cs
+++ b/FGEGraphics/UISystem/UIScreen.cs
@@ -51,6 +51,7 @@ public class UIScreen : UIElement
         Position.GetterWidth(() => Parent == null ? Engine.Window.ClientSize.X : Parent.Position.Width);
         Position.GetterHeight(() => Parent == null ? Engine.Window.ClientSize.Y : Parent.Position.Height);
         RenderPriority = SCREEN_PRIORITY_DEFAULT;
+        Enabled = false;
     }
 
     /// <summary>Constructs a screen that covers a specific portion of the game window.</summary>
@@ -60,6 +61,7 @@ public class UIScreen : UIElement
     {
         InternalClient = client;
         IsValid = true;
+        Enabled = false;
     }
 
     /// <summary>Performs a render on this element.</summary>

--- a/FGEGraphics/UISystem/UIScreen.cs
+++ b/FGEGraphics/UISystem/UIScreen.cs
@@ -51,17 +51,15 @@ public class UIScreen : UIElement
         Position.GetterWidth(() => Parent == null ? Engine.Window.ClientSize.X : Parent.Position.Width);
         Position.GetterHeight(() => Parent == null ? Engine.Window.ClientSize.Y : Parent.Position.Height);
         RenderPriority = SCREEN_PRIORITY_DEFAULT;
-        Enabled = false;
     }
 
     /// <summary>Constructs a screen that covers a specific portion of the game window.</summary>
     /// <param name="client">The client game window.</param>
     /// <param name="pos">The position of the element.</param>
-    public UIScreen(GameClientWindow client, UIPositionHelper pos) : base(pos)
+    public UIScreen(GameClientWindow client, UIPositionHelper pos) : base(pos, enabled: false)
     {
         InternalClient = client;
         IsValid = true;
-        Enabled = false;
     }
 
     /// <summary>Performs a render on this element.</summary>

--- a/FGEGraphics/UISystem/UIScrollBox.cs
+++ b/FGEGraphics/UISystem/UIScrollBox.cs
@@ -20,7 +20,7 @@ namespace FGEGraphics.UISystem;
 /// <summary>Represents a scrollable box containing other elements.</summary>
 /// <remarks>Constructs the UI scroll box.</remarks>
 /// <param name="pos">The position of the element.</param>
-public class UIScrollBox(UIPositionHelper pos) : UIElement(pos)
+public class UIScrollBox(UIPositionHelper pos) : UIElement(pos, enabled: false)
 {
     /// <summary>The current scroll position.</summary>
     public int Scroll = 0;

--- a/FGEGraphics/UISystem/UITabGroup.cs
+++ b/FGEGraphics/UISystem/UITabGroup.cs
@@ -28,7 +28,7 @@ public record TabSwitchedArgs(UIScreen From, UIScreen To);
 public class UITabGroup(UIPositionHelper pos, Action<TabSwitchedArgs> onSwitch = null) : UIGroup(pos)
 {
     /// <summary>Ran when the tab is switched.</summary>
-    public event Action<TabSwitchedArgs> TabSwitched = onSwitch;
+    public Action<TabSwitchedArgs> TabSwitched = onSwitch;
 
     /// <summary>The button leading to the currently selected tab.</summary>
     public UIElement SelectedButton;

--- a/FGEGraphics/UISystem/UITextLink.cs
+++ b/FGEGraphics/UISystem/UITextLink.cs
@@ -38,12 +38,10 @@ public class UITextLink : UIClickableElement
     /// <param name="alignment">The text alignment to use.</param>
     /// <param name="icon">The icon to display alongside the text.</param>
     /// <param name="clicked">The action to run when clicked.</param>
-    /// <param name="normal">The style to display when neither hovered nor clicked.</param>
-    /// <param name="hover">The style to display when hovered.</param>
-    /// <param name="click">The style to display when clicked.</param>
+    /// <param name="styles">The clickable styles.</param>
     /// <param name="pos">The position of the element.</param>
-    public UITextLink(string text, Texture icon, Action clicked, UIElementStyle normal, UIElementStyle hover, UIElementStyle click, UIPositionHelper pos, TextAlignment alignment = TextAlignment.LEFT)
-        : base(normal, hover, click, pos, true, clicked)
+    public UITextLink(string text, Texture icon, Action clicked, StyleGroup styles, UIPositionHelper pos, TextAlignment alignment = TextAlignment.LEFT)
+        : base(styles, pos, true, clicked)
     {
         Text = new(this, text, true, horizontalAlignment: alignment);
         Icon = icon;

--- a/FGEGraphics/UISystem/UITextLink.cs
+++ b/FGEGraphics/UISystem/UITextLink.cs
@@ -46,10 +46,8 @@ public class UITextLink : UIClickableElement
         Text = new(this, text, true, horizontalAlignment: alignment);
         Icon = icon;
         UpdateStyle();
+        Position.GetterWidthHeight(() => Text.Width, () => Text.Height);
     }
-
-    /// <summary>Fixes this text link's width and height based on <see cref="Text"/> and the current style.</summary>
-    public override void SwitchToStyle(UIElementStyle style) => Position.ConstantWidthHeight(Text.Width, Text.Height);
 
     /// <summary>Performs a render on this link.</summary>
     /// <param name="view">The UI view.</param>


### PR DESCRIPTION
## Additions

- `UINumberSlider`. Supports decimal mode and grid-based int mode.
- `UILabeledNumberSlider`. Extension of the previous element that displays a label alongside the slider.

## Changes

- Various bugfixes to the existing UI system
- Created `UIClickableElement.StyleGroup` to group the 3 clickable element styles that were taking up too much parameter space

## Still TODO

- [x] Hovering over child elements triggers a hover in the parent element. For a labeled number slider, that means you can hover over / click the label and it'll start sliding. That's weird, and should find a way to fix that.
- [x] When held down, users' mice should be able to exit the boundaries of a slider and still modify its value. It's bad UX otherwise. The problem is that other elements will still be hoverable/pressable, so need to find some way to "lock" them while a "persistent press" is happening.
- [ ] The label in `UILabeledNumberSlider` should be editable.
  - This is in progress over at the `new-text-input` branch
- [ ] The label updates its position one frame after its text being edited. Need to fix that.