### PR TITLE
UI Debug Mode Improvements

### DIFF
--- a/FGEGraphics/ClientSystem/ViewUI2D.cs
+++ b/FGEGraphics/ClientSystem/ViewUI2D.cs
@@ -25,6 +25,7 @@ using OpenTK.Graphics;
 using OpenTK.Graphics.OpenGL4;
 using OpenTK.Mathematics;
 using OpenTK.Windowing.GraphicsLibraryFramework;
+using OpenTK.Windowing.Common;
 
 namespace FGEGraphics.ClientSystem;
 
@@ -86,13 +87,17 @@ public class ViewUI2D
         /// <summary>Whether scroll input is still available to consume for the current step.</summary>
         public bool Scrolled;
 
-        public bool ShowDebugTree = true;
+        /// <summary>Whether to draw textual debug information about the hovered elements, if any.</summary>
+        public bool ShowDebugInfo = true;
 
-        public int DebugTreeIndex = 0;
+        /// <summary>The list position of the entry at the top of the debug info tree.</summary>
+        public int DebugInfoStartIndex = 0;
 
-        public int DebugTreeEntries = 5;
+        /// <summary>The number of entries displayed in the debug info tree.</summary>
+        public int DebugInfoEntries = 5;
 
-        public int DebugTreeSize;
+        /// <summary>The total size of the debug info tree.</summary>
+        public int DebugInfoTreeSize;
     }
 
     /// <summary>Data internal to a <see cref="ViewUI2D"/> instance.</summary>
@@ -105,42 +110,7 @@ public class ViewUI2D
         Client = client;
         DefaultScreen = new UIScreen(this);
         CurrentScreen = DefaultScreen;
-        Client.Window.KeyDown += args =>
-        {
-            if (args.Key == Keys.F4)
-            {
-                IsDebug = !IsDebug;
-            }
-            if (args.Alt)
-            {
-                if (args.Shift)
-                {
-                    if (args.Key == Keys.KeyPad2 && Internal.DebugTreeEntries > 1)
-                    {
-                        Internal.DebugTreeEntries--;
-                    }
-                    else if (args.Key == Keys.KeyPad8 && Internal.DebugTreeEntries < Internal.DebugTreeSize)
-                    {
-                        Internal.DebugTreeEntries++;
-                    }
-                }
-                else
-                {
-                    if (args.Key == Keys.KeyPad5)
-                    {
-                        Internal.ShowDebugTree = !Internal.ShowDebugTree;
-                    }
-                    else if (args.Key == Keys.KeyPad2)
-                    {
-                        Internal.DebugTreeIndex++;
-                    }
-                    else if (args.Key == Keys.KeyPad8 && Internal.DebugTreeIndex > 0)
-                    {
-                        Internal.DebugTreeIndex--;
-                    }
-                }
-            }
-        };
+        Client.Window.KeyDown += HandleKeyEvent;
     }
 
     /// <summary>Draws wireframe outlines of the elements on-screen for debugging.</summary>
@@ -160,9 +130,8 @@ public class ViewUI2D
         }
     }
 
-    // TODO: renamings needed
-    /// <summary>Draws information specific to debug mode.</summary>
-    public void DrawDebugTree()
+    /// <summary>Draws debug information about the hovered elements, if any.</summary>
+    public void DrawDebugInfoTree()
     {
         Stack<(int, IEnumerable<string>)> infoStack = [];
         foreach (UIElement element in CurrentScreen.AllChildren())
@@ -174,16 +143,18 @@ public class ViewUI2D
             }
         }
         // TODO: purify
-        Internal.DebugTreeSize = infoStack.Count;
-        //Internal.DebugTreeIndex = Math.Max(Internal.DebugTreeIndex, Internal.DebugTreeSize - 1);
+        Internal.DebugInfoTreeSize = infoStack.Count;
+        Internal.DebugInfoStartIndex = Math.Max(0, Math.Min(Internal.DebugInfoStartIndex, Internal.DebugInfoTreeSize - 1));
         if (infoStack.Count == 0)
         {
             return;
         }
-        // TODO: track max
-        int index = Math.Min(Internal.DebugTreeIndex, infoStack.Count);
-        Range infoRange = new(index, Math.Min(index + Internal.DebugTreeEntries, infoStack.Count));
+        Range infoRange = new(Internal.DebugInfoStartIndex, Math.Min(Internal.DebugInfoStartIndex + Internal.DebugInfoEntries, infoStack.Count));
         int numberInfoEntries = infoRange.End.Value - infoRange.Start.Value;
+        if (numberInfoEntries <= 0)
+        {
+            return;
+        }
         IEnumerable<(int, IEnumerable<string>)> infoChunk = infoStack.Take(infoRange);
         int minimumTreeLevel = infoChunk.Min(entry => entry.Item1);
         string debugInfo = infoChunk.Select(entry =>
@@ -263,9 +234,9 @@ public class ViewUI2D
         if (IsDebug)
         {
             DrawDebugOutlines();
-            if (Internal.ShowDebugTree)
+            if (Internal.ShowDebugInfo)
             {
-                DrawDebugTree();
+                DrawDebugInfoTree();
             }
         }
         GraphicsUtil.CheckError("ViewUI2D - Draw - PostDraw");
@@ -296,5 +267,42 @@ public class ViewUI2D
         }
         MousePreviouslyDown = MouseDown;
         Internal.Scrolled = false;
+    }
+
+    public void HandleKeyEvent(KeyboardKeyEventArgs args)
+    {
+        if (args.Key == Keys.F4)
+        {
+            IsDebug = !IsDebug;
+        }
+        if (args.Alt)
+        {
+            if (args.Shift)
+            {
+                if (args.Key == Keys.KeyPad2 && Internal.DebugInfoEntries > 1)
+                {
+                    Internal.DebugInfoEntries--;
+                }
+                else if (args.Key == Keys.KeyPad8 && Internal.DebugInfoEntries < Internal.DebugInfoTreeSize)
+                {
+                    Internal.DebugInfoEntries++;
+                }
+            }
+            else
+            {
+                if (args.Key == Keys.KeyPad5)
+                {
+                    Internal.ShowDebugInfo = !Internal.ShowDebugInfo;
+                }
+                else if (args.Key == Keys.KeyPad2 && Internal.DebugInfoStartIndex < Internal.DebugInfoTreeSize - 1)
+                {
+                    Internal.DebugInfoStartIndex++;
+                }
+                else if (args.Key == Keys.KeyPad8 && Internal.DebugInfoStartIndex > 0)
+                {
+                    Internal.DebugInfoStartIndex--;
+                }
+            }
+        }
     }
 }

--- a/FGEGraphics/ClientSystem/ViewUI2D.cs
+++ b/FGEGraphics/ClientSystem/ViewUI2D.cs
@@ -20,6 +20,7 @@ using FGEGraphics.GraphicsHelpers;
 using FGEGraphics.GraphicsHelpers.FontSets;
 using FGEGraphics.GraphicsHelpers.Shaders;
 using FGEGraphics.UISystem;
+using FreneticUtilities.FreneticExtensions;
 using OpenTK;
 using OpenTK.Graphics;
 using OpenTK.Graphics.OpenGL4;
@@ -30,7 +31,7 @@ using OpenTK.Windowing.Common;
 namespace FGEGraphics.ClientSystem;
 
 // toggle debug mode: f4
-// toggle tree: alt kp5
+// cycle thru hover info: alt kp5
 // scroll tree: alt kp2, kp8
 // expand/contract tree: shift scroll
 // scroll view modes: alt kp4, kp6
@@ -38,6 +39,8 @@ namespace FGEGraphics.ClientSystem;
 /// <summary>A 2D UI view.</summary>
 public class ViewUI2D
 {
+    public static readonly string DEBUG_BASE_COLOR = "^r^0^h^o^e";
+
     /// <summary>The backing client window.</summary>
     public GameClientWindow Client;
 
@@ -93,8 +96,13 @@ public class ViewUI2D
         /// <summary>Whether scroll input is still available to consume for the current step.</summary>
         public bool Scrolled;
 
+        public Stack<UIElement> DebugHoveredElements = [];
+
         /// <summary>Whether to draw textual debug information about the hovered elements, if any.</summary>
         public bool ShowDebugInfo = true;
+
+        /// <summary>Whether to draw the debug information at the cursor position.</summary>
+        public bool ShowDetailedDebugInfo = false;
 
         /// <summary>The list position of the entry at the top of the debug info tree.</summary>
         public int DebugInfoStartIndex = 0;
@@ -128,33 +136,19 @@ public class ViewUI2D
             Color4F outlineColor = element == HeldElement ? Color4F.Green : element.ElementInternal.IsMouseHovered ? Color4F.Yellow : Color4F.Red;
             Renderer2D.SetColor(outlineColor);
             Rendering.RenderRectangle(UIContext, element.X + 1, element.Y + 1, element.X + element.Width - 1, element.Y + element.Height - 1, new(-0.5f, -0.5f, element.Rotation), true);
+            // TODO: rendering stroke thickness
             if (element == HeldElement)
             {
-                Rendering.RenderRectangle(UIContext, element.X + 1, element.Y + 1, element.X + element.Width - 1, element.Y + element.Height - 1, new(-0.5f, -0.5f, element.Rotation), true);
+                Rendering.RenderRectangle(UIContext, element.X, element.Y, element.X + element.Width, element.Y + element.Height, new(-0.5f, -0.5f, element.Rotation), true);
+                Rendering.RenderRectangle(UIContext, element.X + 2, element.Y + 2, element.X + element.Width - 2, element.Y + element.Height - 2, new(-0.5f, -0.5f, element.Rotation), true);
             }
             Renderer2D.SetColor(Color4F.White);
         }
     }
 
     /// <summary>Draws debug information about the hovered elements, if any.</summary>
-    public void DrawDebugInfoTree()
+    public void DrawDebugInfoTree(Stack<(int, IEnumerable<string>)> infoStack)
     {
-        Stack<(int, IEnumerable<string>)> infoStack = [];
-        foreach (UIElement element in CurrentScreen.AllChildren())
-        {
-            if (element.ElementInternal.IsMouseHovered && element.AllowDebug)
-            {
-                List<string> infoLines = [.. element.GetBaseDebugInfo("^r^0^h^o^e"), .. element.GetDebugInfo()];
-                infoStack.Push((element.ElementInternal.TreeLevel, infoLines.Select(line => $"^r^0^h^o^e{line}^r")));
-            }
-        }
-        // TODO: purify
-        Internal.DebugInfoTreeSize = infoStack.Count;
-        Internal.DebugInfoStartIndex = Math.Max(0, Math.Min(Internal.DebugInfoStartIndex, Internal.DebugInfoTreeSize - 1));
-        if (infoStack.Count == 0)
-        {
-            return;
-        }
         Range infoRange = new(Internal.DebugInfoStartIndex, Math.Min(Internal.DebugInfoStartIndex + Internal.DebugInfoEntries, infoStack.Count));
         int numberInfoEntries = infoRange.End.Value - infoRange.Start.Value;
         if (numberInfoEntries <= 0)
@@ -169,9 +163,53 @@ public class ViewUI2D
                 return entry.Item2.Select(line => $"{prefix}{line}").JoinString("\n");
             })
             .JoinString("\n\n");
-        debugInfo += $"\n\n^r^0^h^o^e^&[{infoRange.Start}] - ^3[{numberInfoEntries}] ^&- [{infoStack.Count - infoRange.End.Value}]^r";
+        debugInfo += $"\n\n{DEBUG_BASE_COLOR}^&[{infoRange.Start}] - ^3[{numberInfoEntries}] ^&- [{infoStack.Count - infoRange.End.Value}]^r";
         RenderableText text = Client.FontSets.Standard.ParseFancyText(debugInfo, "^r^0^e^7");
         Client.FontSets.Standard.DrawFancyText(text, new Location(10, (int)(Client.WindowHeight - text.Height - 10), 0));
+    }
+
+    public void DrawDebug()
+    {
+        List<UIElement> hoveredElements = [];
+        foreach (UIElement element in CurrentScreen.AllChildren())
+        {
+            if (element.ElementInternal.IsMouseHovered && element.AllowDebug)
+            {
+                hoveredElements.Add(element);
+            }
+        }
+        hoveredElements.Reverse();
+        Internal.DebugInfoTreeSize = hoveredElements.Count;
+        Internal.DebugInfoStartIndex = Math.Max(0, Math.Min(Internal.DebugInfoStartIndex, Internal.DebugInfoTreeSize - 1));
+        DrawDebugOutlines();
+        if (Internal.ShowDebugInfo && hoveredElements.Count > 0)
+        {
+            if (Internal.ShowDetailedDebugInfo)
+            {
+                UIElement element = hoveredElements.ElementAt(Internal.DebugInfoStartIndex);
+                RenderableText text = Client.FontSets.Standard.ParseFancyText(element.GetAllDebugInfo(DEBUG_BASE_COLOR));
+                Client.FontSets.Standard.DrawFancyText(text, new Location(10, (int)(Client.WindowHeight - text.Height - 10), 0));
+            }
+            else
+            {
+                Range infoRange = new(Internal.DebugInfoStartIndex, Math.Min(Internal.DebugInfoStartIndex + Internal.DebugInfoEntries, hoveredElements.Count));
+                int numberInfoEntries = infoRange.End.Value - infoRange.Start.Value;
+                if (numberInfoEntries > 0)
+                {
+                    IEnumerable<UIElement> chunk = hoveredElements.Take(infoRange);
+                    int minimumTreeLevel = chunk.Min(element => element.ElementInternal.TreeLevel);
+                    string debugInfo = chunk.Select(element =>
+                    {
+                        string spacing = new(' ', (element.ElementInternal.TreeLevel - minimumTreeLevel) * 2);
+                        return element.GetBaseDebugInfo(DEBUG_BASE_COLOR, detailed: false).Select(line => $"^r{spacing}{DEBUG_BASE_COLOR}{line}").JoinString("\n");
+                    })
+                    .JoinString("\n\n");
+                    debugInfo += $"\n\n{DEBUG_BASE_COLOR}^&[{infoRange.Start}] - ^3[{numberInfoEntries}] ^&- [{hoveredElements.Count - infoRange.End.Value}]^r";
+                    RenderableText text = Client.FontSets.Standard.ParseFancyText(debugInfo, "^r^0^e^7");
+                    Client.FontSets.Standard.DrawFancyText(text, new Location(10, (int)(Client.WindowHeight - text.Height - 10), 0));
+                }
+            }
+        }
     }
 
     /// <summary>Draw the menu to the relevant back buffer.</summary>
@@ -239,11 +277,7 @@ public class ViewUI2D
         CurrentScreen.RenderAll(Client.Delta);
         if (IsDebug)
         {
-            DrawDebugOutlines();
-            if (Internal.ShowDebugInfo)
-            {
-                DrawDebugInfoTree();
-            }
+            DrawDebug();
         }
         GraphicsUtil.CheckError("ViewUI2D - Draw - PostDraw");
         Client.FontSets.FixToShader = s;
@@ -275,6 +309,7 @@ public class ViewUI2D
         Internal.Scrolled = false;
     }
 
+    /// <summary>Listens for debug keybinds and updates <see cref="Internal"/> accordingly.</summary>
     public void HandleKeyEvent(KeyboardKeyEventArgs args)
     {
         if (args.Key == Keys.F4)
@@ -285,6 +320,10 @@ public class ViewUI2D
         {
             if (args.Shift)
             {
+                if (args.Key == Keys.KeyPad5)
+                {
+                    Internal.ShowDetailedDebugInfo = !Internal.ShowDetailedDebugInfo;
+                }
                 if (args.Key == Keys.KeyPad2 && Internal.DebugInfoEntries > 1)
                 {
                     Internal.DebugInfoEntries--;

--- a/FGEGraphics/ClientSystem/ViewUI2D.cs
+++ b/FGEGraphics/ClientSystem/ViewUI2D.cs
@@ -29,6 +29,12 @@ using OpenTK.Windowing.Common;
 
 namespace FGEGraphics.ClientSystem;
 
+// toggle debug mode: f4
+// toggle tree: alt kp5
+// scroll tree: alt kp2, kp8
+// expand/contract tree: shift scroll
+// scroll view modes: alt kp4, kp6
+
 /// <summary>A 2D UI view.</summary>
 public class ViewUI2D
 {
@@ -138,7 +144,7 @@ public class ViewUI2D
         {
             if (element.ElementInternal.IsMouseHovered && element.AllowDebug)
             {
-                List<string> infoLines = [.. element.GetBaseDebugInfo(), .. element.GetDebugInfo()];
+                List<string> infoLines = [.. element.GetBaseDebugInfo("^r^0^h^o^e"), .. element.GetDebugInfo()];
                 infoStack.Push((element.ElementInternal.TreeLevel, infoLines.Select(line => $"^r^0^h^o^e{line}^r")));
             }
         }

--- a/FGEGraphics/ClientSystem/ViewUI2D.cs
+++ b/FGEGraphics/ClientSystem/ViewUI2D.cs
@@ -39,6 +39,7 @@ namespace FGEGraphics.ClientSystem;
 /// <summary>A 2D UI view.</summary>
 public class ViewUI2D
 {
+    /// <summary>The base text styling for debug information.</summary>
     public static readonly string DEBUG_BASE_COLOR = "^r^0^h^o^e";
 
     /// <summary>The backing client window.</summary>
@@ -96,8 +97,6 @@ public class ViewUI2D
         /// <summary>Whether scroll input is still available to consume for the current step.</summary>
         public bool Scrolled;
 
-        public Stack<UIElement> DebugHoveredElements = [];
-
         /// <summary>Whether to draw textual debug information about the hovered elements, if any.</summary>
         public bool ShowDebugInfo = true;
 
@@ -146,28 +145,31 @@ public class ViewUI2D
         }
     }
 
-    /// <summary>Draws debug information about the hovered elements, if any.</summary>
-    public void DrawDebugInfoTree(Stack<(int, IEnumerable<string>)> infoStack)
+    /// <summary>Gets debug information about the hovered elements, if any.</summary>
+    public string GetDebugInfo(List<UIElement> hoveredElements)
     {
-        Range infoRange = new(Internal.DebugInfoStartIndex, Math.Min(Internal.DebugInfoStartIndex + Internal.DebugInfoEntries, infoStack.Count));
+        if (Internal.ShowDetailedDebugInfo)
+        {
+            return hoveredElements[Internal.DebugInfoStartIndex].GetAllDebugInfo(DEBUG_BASE_COLOR);
+        }
+        Range infoRange = new(Internal.DebugInfoStartIndex, Math.Min(Internal.DebugInfoStartIndex + Internal.DebugInfoEntries, hoveredElements.Count));
         int numberInfoEntries = infoRange.End.Value - infoRange.Start.Value;
         if (numberInfoEntries <= 0)
         {
-            return;
+            return null;
         }
-        IEnumerable<(int, IEnumerable<string>)> infoChunk = infoStack.Take(infoRange);
-        int minimumTreeLevel = infoChunk.Min(entry => entry.Item1);
-        string debugInfo = infoChunk.Select(entry =>
+        IEnumerable<UIElement> elementsToDisplay = hoveredElements.Take(infoRange);
+        int minimumTreeLevel = elementsToDisplay.Min(element => element.ElementInternal.TreeLevel);
+        string debugInfo = elementsToDisplay.Select(element =>
             {
-                string prefix = new(' ', (entry.Item1 - minimumTreeLevel) * 2);
-                return entry.Item2.Select(line => $"{prefix}{line}").JoinString("\n");
+                string spacing = new(' ', (element.ElementInternal.TreeLevel - minimumTreeLevel) * 2);
+                return element.GetBaseDebugInfo(DEBUG_BASE_COLOR, detailed: false).Select(line => $"^r{spacing}{DEBUG_BASE_COLOR}{line}").JoinString("\n");
             })
             .JoinString("\n\n");
-        debugInfo += $"\n\n{DEBUG_BASE_COLOR}^&[{infoRange.Start}] - ^3[{numberInfoEntries}] ^&- [{infoStack.Count - infoRange.End.Value}]^r";
-        RenderableText text = Client.FontSets.Standard.ParseFancyText(debugInfo, "^r^0^e^7");
-        Client.FontSets.Standard.DrawFancyText(text, new Location(10, (int)(Client.WindowHeight - text.Height - 10), 0));
+        return debugInfo + $"\n\n{DEBUG_BASE_COLOR}^&[{infoRange.Start}] - ^3[{numberInfoEntries}] ^&- [{hoveredElements.Count - infoRange.End.Value}]^r";
     }
 
+    /// <summary>Draws debug information over the current screen.</summary>
     public void DrawDebug()
     {
         List<UIElement> hoveredElements = [];
@@ -182,33 +184,10 @@ public class ViewUI2D
         Internal.DebugInfoTreeSize = hoveredElements.Count;
         Internal.DebugInfoStartIndex = Math.Max(0, Math.Min(Internal.DebugInfoStartIndex, Internal.DebugInfoTreeSize - 1));
         DrawDebugOutlines();
-        if (Internal.ShowDebugInfo && hoveredElements.Count > 0)
+        if (Internal.ShowDebugInfo && hoveredElements.Count > 0 && GetDebugInfo(hoveredElements) is string debugInfo)
         {
-            if (Internal.ShowDetailedDebugInfo)
-            {
-                UIElement element = hoveredElements.ElementAt(Internal.DebugInfoStartIndex);
-                RenderableText text = Client.FontSets.Standard.ParseFancyText(element.GetAllDebugInfo(DEBUG_BASE_COLOR));
-                Client.FontSets.Standard.DrawFancyText(text, new Location(10, (int)(Client.WindowHeight - text.Height - 10), 0));
-            }
-            else
-            {
-                Range infoRange = new(Internal.DebugInfoStartIndex, Math.Min(Internal.DebugInfoStartIndex + Internal.DebugInfoEntries, hoveredElements.Count));
-                int numberInfoEntries = infoRange.End.Value - infoRange.Start.Value;
-                if (numberInfoEntries > 0)
-                {
-                    IEnumerable<UIElement> chunk = hoveredElements.Take(infoRange);
-                    int minimumTreeLevel = chunk.Min(element => element.ElementInternal.TreeLevel);
-                    string debugInfo = chunk.Select(element =>
-                    {
-                        string spacing = new(' ', (element.ElementInternal.TreeLevel - minimumTreeLevel) * 2);
-                        return element.GetBaseDebugInfo(DEBUG_BASE_COLOR, detailed: false).Select(line => $"^r{spacing}{DEBUG_BASE_COLOR}{line}").JoinString("\n");
-                    })
-                    .JoinString("\n\n");
-                    debugInfo += $"\n\n{DEBUG_BASE_COLOR}^&[{infoRange.Start}] - ^3[{numberInfoEntries}] ^&- [{hoveredElements.Count - infoRange.End.Value}]^r";
-                    RenderableText text = Client.FontSets.Standard.ParseFancyText(debugInfo, "^r^0^e^7");
-                    Client.FontSets.Standard.DrawFancyText(text, new Location(10, (int)(Client.WindowHeight - text.Height - 10), 0));
-                }
-            }
+            RenderableText text = Client.FontSets.Standard.ParseFancyText(debugInfo);
+            Client.FontSets.Standard.DrawFancyText(text, new Location(10, (int)(Client.WindowHeight - text.Height - 10), 0));
         }
     }
 

--- a/FGEGraphics/ClientSystem/ViewUI2D.cs
+++ b/FGEGraphics/ClientSystem/ViewUI2D.cs
@@ -85,6 +85,14 @@ public class ViewUI2D
 
         /// <summary>Whether scroll input is still available to consume for the current step.</summary>
         public bool Scrolled;
+
+        public bool ShowDebugTree = true;
+
+        public int DebugTreeIndex = 0;
+
+        public int DebugTreeEntries = 5;
+
+        public int DebugTreeSize;
     }
 
     /// <summary>Data internal to a <see cref="ViewUI2D"/> instance.</summary>
@@ -97,6 +105,42 @@ public class ViewUI2D
         Client = client;
         DefaultScreen = new UIScreen(this);
         CurrentScreen = DefaultScreen;
+        Client.Window.KeyDown += args =>
+        {
+            if (args.Key == Keys.F4)
+            {
+                IsDebug = !IsDebug;
+            }
+            if (args.Alt)
+            {
+                if (args.Shift)
+                {
+                    if (args.Key == Keys.KeyPad2 && Internal.DebugTreeEntries > 1)
+                    {
+                        Internal.DebugTreeEntries--;
+                    }
+                    else if (args.Key == Keys.KeyPad8 && Internal.DebugTreeEntries < Internal.DebugTreeSize)
+                    {
+                        Internal.DebugTreeEntries++;
+                    }
+                }
+                else
+                {
+                    if (args.Key == Keys.KeyPad5)
+                    {
+                        Internal.ShowDebugTree = !Internal.ShowDebugTree;
+                    }
+                    else if (args.Key == Keys.KeyPad2)
+                    {
+                        Internal.DebugTreeIndex++;
+                    }
+                    else if (args.Key == Keys.KeyPad8 && Internal.DebugTreeIndex > 0)
+                    {
+                        Internal.DebugTreeIndex--;
+                    }
+                }
+            }
+        };
     }
 
     /// <summary>Draws wireframe outlines of the elements on-screen for debugging.</summary>
@@ -108,34 +152,47 @@ public class ViewUI2D
             Color4F outlineColor = element == HeldElement ? Color4F.Green : element.ElementInternal.IsMouseHovered ? Color4F.Yellow : Color4F.Red;
             Renderer2D.SetColor(outlineColor);
             Rendering.RenderRectangle(UIContext, element.X + 1, element.Y + 1, element.X + element.Width - 1, element.Y + element.Height - 1, new(-0.5f, -0.5f, element.Rotation), true);
+            if (element == HeldElement)
+            {
+                Rendering.RenderRectangle(UIContext, element.X + 1, element.Y + 1, element.X + element.Width - 1, element.Y + element.Height - 1, new(-0.5f, -0.5f, element.Rotation), true);
+            }
             Renderer2D.SetColor(Color4F.White);
         }
     }
 
+    // TODO: renamings needed
     /// <summary>Draws information specific to debug mode.</summary>
-    public void DrawDebugInfo()
+    public void DrawDebugTree()
     {
-        Stack<(int, IEnumerable<string>)> debugInfoStack = [];
+        Stack<(int, IEnumerable<string>)> infoStack = [];
         foreach (UIElement element in CurrentScreen.AllChildren())
         {
             if (element.ElementInternal.IsMouseHovered && element.AllowDebug)
             {
-                List<string> debugLines = [.. element.GetBaseDebugInfo(), .. element.GetDebugInfo()];
-                debugInfoStack.Push((element.ElementInternal.TreeLevel, debugLines.Select(line => $"^r^0^h^o^e{line}^r")));
+                List<string> infoLines = [.. element.GetBaseDebugInfo(), .. element.GetDebugInfo()];
+                infoStack.Push((element.ElementInternal.TreeLevel, infoLines.Select(line => $"^r^0^h^o^e{line}^r")));
             }
         }
-        if (debugInfoStack.Count == 0)
+        // TODO: purify
+        Internal.DebugTreeSize = infoStack.Count;
+        //Internal.DebugTreeIndex = Math.Max(Internal.DebugTreeIndex, Internal.DebugTreeSize - 1);
+        if (infoStack.Count == 0)
         {
             return;
         }
-        IEnumerable<(int, IEnumerable<string>)> topDebugStack = debugInfoStack.Take(Math.Min(5, debugInfoStack.Count));
-        int minimumTreeLevel = topDebugStack.Min(entry => entry.Item1);
-        string debugInfo = topDebugStack.Select(entry =>
+        // TODO: track max
+        int index = Math.Min(Internal.DebugTreeIndex, infoStack.Count);
+        Range infoRange = new(index, Math.Min(index + Internal.DebugTreeEntries, infoStack.Count));
+        int numberInfoEntries = infoRange.End.Value - infoRange.Start.Value;
+        IEnumerable<(int, IEnumerable<string>)> infoChunk = infoStack.Take(infoRange);
+        int minimumTreeLevel = infoChunk.Min(entry => entry.Item1);
+        string debugInfo = infoChunk.Select(entry =>
             {
                 string prefix = new(' ', (entry.Item1 - minimumTreeLevel) * 2);
                 return entry.Item2.Select(line => $"{prefix}{line}").JoinString("\n");
             })
             .JoinString("\n\n");
+        debugInfo += $"\n\n^r^0^h^o^e^&[{infoRange.Start}] - ^3[{numberInfoEntries}] ^&- [{infoStack.Count - infoRange.End.Value}]^r";
         RenderableText text = Client.FontSets.Standard.ParseFancyText(debugInfo, "^r^0^e^7");
         Client.FontSets.Standard.DrawFancyText(text, new Location(10, (int)(Client.WindowHeight - text.Height - 10), 0));
     }
@@ -206,10 +263,10 @@ public class ViewUI2D
         if (IsDebug)
         {
             DrawDebugOutlines();
-            //if (Client.Keyboard.BuildingState.AltPressed)
-            //{
-                DrawDebugInfo();
-            //}
+            if (Internal.ShowDebugTree)
+            {
+                DrawDebugTree();
+            }
         }
         GraphicsUtil.CheckError("ViewUI2D - Draw - PostDraw");
         Client.FontSets.FixToShader = s;

--- a/FGEGraphics/ClientSystem/ViewUI2D.cs
+++ b/FGEGraphics/ClientSystem/ViewUI2D.cs
@@ -20,7 +20,6 @@ using FGEGraphics.GraphicsHelpers;
 using FGEGraphics.GraphicsHelpers.FontSets;
 using FGEGraphics.GraphicsHelpers.Shaders;
 using FGEGraphics.UISystem;
-using FreneticUtilities.FreneticExtensions;
 using OpenTK;
 using OpenTK.Graphics;
 using OpenTK.Graphics.OpenGL4;
@@ -155,11 +154,10 @@ public class ViewUI2D
         IEnumerable<UIElement> elementsToDisplay = hoveredElements.Take(infoRange);
         int minimumTreeLevel = elementsToDisplay.Min(element => element.ElementInternal.TreeLevel);
         string debugInfo = elementsToDisplay.Select(element =>
-            {
-                string spacing = new(' ', (element.ElementInternal.TreeLevel - minimumTreeLevel) * 2);
-                return element.GetBaseDebugInfo(DEBUG_BASE_COLOR, detailed: false).Select(line => $"^r{spacing}{DEBUG_BASE_COLOR}{line}").JoinString("\n");
-            })
-            .JoinString("\n\n");
+        {
+            string spacing = new(' ', (element.ElementInternal.TreeLevel - minimumTreeLevel) * 2);
+            return element.GetBaseDebugInfo(DEBUG_BASE_COLOR, detailed: false).Select(line => $"^r{spacing}{DEBUG_BASE_COLOR}{line}").JoinString("\n");
+        }).JoinString("\n\n");
         return debugInfo + $"\n\n{DEBUG_BASE_COLOR}^&[{infoRange.Start}] - ^3[{numberInfoEntries}] ^&- [{hoveredElements.Count - infoRange.End.Value}]^r";
     }
 

--- a/FGEGraphics/ClientSystem/ViewUI2D.cs
+++ b/FGEGraphics/ClientSystem/ViewUI2D.cs
@@ -30,12 +30,6 @@ using OpenTK.Windowing.Common;
 
 namespace FGEGraphics.ClientSystem;
 
-// toggle debug mode: f4
-// cycle thru hover info: alt kp5
-// scroll tree: alt kp2, kp8
-// expand/contract tree: shift scroll
-// scroll view modes: alt kp4, kp6
-
 /// <summary>A 2D UI view.</summary>
 public class ViewUI2D
 {

--- a/FGEGraphics/UISystem/UIBox.cs
+++ b/FGEGraphics/UISystem/UIBox.cs
@@ -25,7 +25,7 @@ namespace FGEGraphics.UISystem;
 public class UIBox : UIElement
 {
     /// <inheritdoc/>
-    public override string Name => OnClick is null ? "Button" : "Box";
+    public override string Name => OnClick is not null ? "Button" : "Box";
 
     // TODO: move to UILayout
     /// <summary>Whether this box is vertically flipped.</summary>

--- a/FGEGraphics/UISystem/UIDebug.cs
+++ b/FGEGraphics/UISystem/UIDebug.cs
@@ -1,3 +1,4 @@
+using FGEGraphics.ClientSystem;
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -6,6 +7,9 @@ using System.Threading.Tasks;
 
 namespace FGEGraphics.UISystem;
 
+/// <summary>
+/// Indicates that a property or field should be displayed in debug mode (when <see cref="ViewUI2D.IsDebug"/> is <c>true</c>).
+/// </summary>
 [AttributeUsage(AttributeTargets.Property | AttributeTargets.Field)]
 public class UIDebugAttribute : Attribute
 {

--- a/FGEGraphics/UISystem/UIDebug.cs
+++ b/FGEGraphics/UISystem/UIDebug.cs
@@ -1,0 +1,12 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace FGEGraphics.UISystem;
+
+[AttributeUsage(AttributeTargets.Property | AttributeTargets.Field)]
+public class UIDebugAttribute : Attribute
+{
+}

--- a/FGEGraphics/UISystem/UIDropdown.cs
+++ b/FGEGraphics/UISystem/UIDropdown.cs
@@ -31,6 +31,7 @@ public class UIDropdown : UIElement
     public override string Name => "Dropdown";
 
     /// <summary>The text to display when no choice is selected.</summary>
+    [UIDebug]
     public string PlaceholderInfo;
 
     /// <summary>The button to open the dropdown.</summary>

--- a/FGEGraphics/UISystem/UIElement.cs
+++ b/FGEGraphics/UISystem/UIElement.cs
@@ -806,6 +806,8 @@ public abstract class UIElement
     /// </summary>
     public virtual List<string> GetDebugInfo() => [];
 
+    /// <summary>Returns complete debug information, including all base and extra text, about this element.</summary>
+    /// <param name="baseColor">The base text styling.</param>
     public string GetAllDebugInfo(string baseColor)
     {
         List<string> info = GetBaseDebugInfo(baseColor, detailed: true);

--- a/FGEGraphics/UISystem/UIElement.cs
+++ b/FGEGraphics/UISystem/UIElement.cs
@@ -819,7 +819,8 @@ public abstract class UIElement
                     : null;
                 if (value is not null)
                 {
-                    info.Add($"^7{memberInfo.Name}: ^3{value}");
+                    string color = value is bool boolValue ? (boolValue ? "2" : "1") : "3";
+                    info.Add($"^7{memberInfo.Name}: ^{color}{value}");
                 }
             }
         }

--- a/FGEGraphics/UISystem/UIElement.cs
+++ b/FGEGraphics/UISystem/UIElement.cs
@@ -16,6 +16,7 @@ using FGECore.MathHelpers;
 using FGEGraphics.ClientSystem;
 using FGEGraphics.GraphicsHelpers;
 using FGEGraphics.UISystem.InputSystems;
+using FreneticUtilities.FreneticExtensions;
 using OpenTK.Mathematics;
 
 using Vector2i = FGECore.MathHelpers.Vector2i;
@@ -777,23 +778,38 @@ public abstract class UIElement
     {
     }
 
-    /// <summary>
-    /// 
-    /// </summary>
-    /// <returns></returns>
-    public List<string> GetBaseDebugInfo(string baseColor)
+    /// <summary>Returns the base debug text to display when debug mode is enabled (see <see cref="ViewUI2D.IsDebug"/>)..</summary>
+    /// <param name="baseColor">The base text styling.</param>
+    /// <param name="detailed">Whether to include extra base information.</param>
+    public List<string> GetBaseDebugInfo(string baseColor, bool detailed)
     {
-        string name = Name ?? GetType().ToString();
-        List<string> info =
-        [
-            $"^{(this == View.HeldElement ? "2" : "5")}^u{name}{baseColor} ^&[{ElementInternal.TreeLevel}] ^&: ^3({X}, {Y}) ^&: ^3({Width}w, {Height}h) ^&: ^3{Rotation}deg ^&: ^3{Scale}x",
-            //$"^7Enabled: ^{(IsEnabled ? "2" : "1")}{IsEnabled}^&, ^7Hovered: ^{(IsHovered ? "2" : "1")}{IsHovered}^&, ^7Pressed: ^{(IsPressed ? "2" : "1")}{IsPressed}^&, ^7Selected: ^{(IsFocused ? "2" : "1")}{IsFocused}"
-        ];
-        /*if (ElementInternal.Styles.Count > 0)
+        List<string> info = [];
+        string header = $"^{(this == View.HeldElement ? "2" : "5")}^u{Name ?? GetType().ToString()}{baseColor} ^&[{ElementInternal.TreeLevel}]";
+        string transforms = $"^3({X}, {Y}) ^&: ^3({Width}w, {Height}h) ^&: ^3{Rotation}deg ^&: ^3{Scale}x";
+        info.Add(detailed ? header : $"{header} ^&: {transforms}");
+        if (detailed)
         {
-            List<string> styleNames = [.. ElementInternal.Styles.Select(style => style.Name is not null ? $"^{(style == ElementInternal.Style ? "3" : "7")}{style.Name}" : "^1unnamed")];
-            info.Add($"^7Styles: {string.Join("^&, ", styleNames)}");
-        }*/
+            info.Add(transforms);
+            info.Add($"^7Enabled: ^{(IsEnabled ? "2" : "1")}{IsEnabled}^&, ^7Hovered: ^{(IsHovered ? "2" : "1")}{IsHovered}^&, ^7Pressed: ^{(IsPressed ? "2" : "1")}{IsPressed}^&, ^7Selected: ^{(IsFocused ? "2" : "1")}{IsFocused}");
+            if (ElementInternal.Styles.Count > 0)
+            {
+                List<string> styleNames = [.. ElementInternal.Styles.Select(style => style.Name is not null ? $"^{(style == ElementInternal.Style ? "3" : "7")}{style.Name}" : "^1unnamed")];
+                info.Add($"^7Styles: {string.Join("^&, ", styleNames)}");
+            }
+        }
+        return info;
+    }
+
+    /// <summary>
+    /// Returns extra debug text to display when debug mode is enabled (see <see cref="ViewUI2D.IsDebug"/>).
+    /// Properties and fields can be added here automatically with <see cref="UIDebugAttribute"/>.
+    /// </summary>
+    public virtual List<string> GetDebugInfo() => [];
+
+    public string GetAllDebugInfo(string baseColor)
+    {
+        List<string> info = GetBaseDebugInfo(baseColor, detailed: true);
+        info.AddRange(GetDebugInfo());
         foreach (MemberInfo memberInfo in GetType().GetMembers())
         {
             if (memberInfo.IsDefined(typeof(UIDebugAttribute), true))
@@ -807,9 +823,6 @@ public abstract class UIElement
                 }
             }
         }
-        return info;
+        return info.Select(line => baseColor + line).JoinString("\n");
     }
-
-    /// <summary>Returns debug text to display when <see cref="ViewUI2D.IsDebug"/> mode is enabled.</summary>
-    public virtual List<string> GetDebugInfo() => [];
 }

--- a/FGEGraphics/UISystem/UIElement.cs
+++ b/FGEGraphics/UISystem/UIElement.cs
@@ -9,6 +9,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Reflection;
 using System.Text;
 using FGECore.CoreSystems;
 using FGECore.MathHelpers;
@@ -780,19 +781,31 @@ public abstract class UIElement
     /// 
     /// </summary>
     /// <returns></returns>
-    public List<string> GetBaseDebugInfo()
+    public List<string> GetBaseDebugInfo(string baseColor)
     {
         string name = Name ?? GetType().ToString();
         List<string> info =
         [
-            $"^{(this == View.HeldElement ? "2" : "5")}^u{name} ^&[{ElementInternal.TreeLevel}]",
-            $"^7Position: ^3({X}, {Y}) ^&| ^7Size: ^3({Width}w, {Height}h) ^&| ^7Rotation: ^3{Rotation} ^&| ^7Scale: ^3{Scale}x",
-            $"^7Enabled: ^{(IsEnabled ? "2" : "1")}{IsEnabled} ^&| ^7Hovered: ^{(IsHovered ? "2" : "1")}{IsHovered} ^&| ^7Pressed: ^{(IsPressed ? "2" : "1")}{IsPressed} ^&| ^7Selected: ^{(IsFocused ? "2" : "1")}{IsFocused}"
+            $"^{(this == View.HeldElement ? "2" : "5")}^u{name}{baseColor} ^&[{ElementInternal.TreeLevel}] ^&: ^3({X}, {Y}) ^&: ^3({Width}w, {Height}h) ^&: ^3{Rotation}deg ^&: ^3{Scale}x",
+            //$"^7Enabled: ^{(IsEnabled ? "2" : "1")}{IsEnabled}^&, ^7Hovered: ^{(IsHovered ? "2" : "1")}{IsHovered}^&, ^7Pressed: ^{(IsPressed ? "2" : "1")}{IsPressed}^&, ^7Selected: ^{(IsFocused ? "2" : "1")}{IsFocused}"
         ];
-        if (ElementInternal.Styles.Count > 0)
+        /*if (ElementInternal.Styles.Count > 0)
         {
             List<string> styleNames = [.. ElementInternal.Styles.Select(style => style.Name is not null ? $"^{(style == ElementInternal.Style ? "3" : "7")}{style.Name}" : "^1unnamed")];
             info.Add($"^7Styles: {string.Join("^&, ", styleNames)}");
+        }*/
+        foreach (MemberInfo memberInfo in GetType().GetMembers())
+        {
+            if (memberInfo.IsDefined(typeof(UIDebugAttribute), true))
+            {
+                object value = memberInfo is FieldInfo fieldInfo ? fieldInfo.GetValue(this)
+                    : memberInfo is PropertyInfo propertyInfo ? propertyInfo.GetValue(this)
+                    : null;
+                if (value is not null)
+                {
+                    info.Add($"^7{memberInfo.Name}: ^3{value}");
+                }
+            }
         }
         return info;
     }

--- a/FGEGraphics/UISystem/UIElement.cs
+++ b/FGEGraphics/UISystem/UIElement.cs
@@ -778,7 +778,7 @@ public abstract class UIElement
     {
     }
 
-    /// <summary>Returns the base debug text to display when debug mode is enabled (see <see cref="ViewUI2D.IsDebug"/>)..</summary>
+    /// <summary>Returns the base debug text to display when debug mode is enabled (see <see cref="ViewUI2D.IsDebug"/>).</summary>
     /// <param name="baseColor">The base text styling.</param>
     /// <param name="detailed">Whether to include extra base information.</param>
     public List<string> GetBaseDebugInfo(string baseColor, bool detailed)
@@ -812,13 +812,12 @@ public abstract class UIElement
     {
         List<string> info = GetBaseDebugInfo(baseColor, detailed: true);
         info.AddRange(GetDebugInfo());
+        // TODO: This should absolutely not be written this way. Raw reflection at runtime is a no-no!
         foreach (MemberInfo memberInfo in GetType().GetMembers())
         {
             if (memberInfo.IsDefined(typeof(UIDebugAttribute), true))
             {
-                object value = memberInfo is FieldInfo fieldInfo ? fieldInfo.GetValue(this)
-                    : memberInfo is PropertyInfo propertyInfo ? propertyInfo.GetValue(this)
-                    : null;
+                object value = memberInfo is FieldInfo fieldInfo ? fieldInfo.GetValue(this) : memberInfo is PropertyInfo propertyInfo ? propertyInfo.GetValue(this) : null;
                 if (value is not null)
                 {
                     string color = value is bool boolValue ? (boolValue ? "2" : "1") : "3";

--- a/FGEGraphics/UISystem/UIImage.cs
+++ b/FGEGraphics/UISystem/UIImage.cs
@@ -29,6 +29,7 @@ public class UIImage(Texture image, UILayout layout) : UIElement(UIStyling.Empty
     public override string Name => $"Image \"{Image.Name}\"";
 
     /// <summary>The image to display.</summary>
+    [UIDebug]
     public Texture Image = image;
 
     /// <summary>How to fit the image within this element's bounding box.</summary>

--- a/FGEGraphics/UISystem/UIInputLabel.cs
+++ b/FGEGraphics/UISystem/UIInputLabel.cs
@@ -71,9 +71,11 @@ public class UIInputLabel : UIElement
     public UILabel PlaceholderInfo;
 
     /// <summary>Whether the input label supports multiple lines.</summary>
+    [UIDebug]
     public bool Multiline = true;
 
     /// <summary>The max length of the text, or 0 if uncapped.</summary>
+    [UIDebug]
     public int MaxLength = 0;
 
     /// <summary>Data internal to a <see cref="UIInputLabel"/> instance.</summary>

--- a/FGEGraphics/UISystem/UILabel.cs
+++ b/FGEGraphics/UISystem/UILabel.cs
@@ -70,6 +70,7 @@ public class UILabel : UIElement
     /// Gets or sets the maximum width of the text content.
     /// <b>Note:</b> setting this value recomputes the <see cref="RenderableText"/> cache.
     /// </summary>
+    [UIDebug]
     public int MaxWidth
     {
         get => Internal.MaxWidth;

--- a/FGEGraphics/UISystem/UIListGroup.cs
+++ b/FGEGraphics/UISystem/UIListGroup.cs
@@ -25,12 +25,15 @@ public class UIListGroup : UIGroup
     public override string Name => "List";
 
     /// <summary>Whether the list should expand vertically.</summary>
+    [UIDebug]
     public bool Vertical;
 
     /// <summary>The spacing between each list item.</summary>
+    [UIDebug]
     public int Spacing;
 
     /// <summary>The anchor that the list will expand from.</summary>
+    [UIDebug]
     public UIAnchor Anchor;
 
     /// <summary>The list of elements currently contained within the list.</summary>

--- a/FGEGraphics/UISystem/UINumberInputLabel.cs
+++ b/FGEGraphics/UISystem/UINumberInputLabel.cs
@@ -30,15 +30,19 @@ public class UINumberInputLabel : UIInputLabel
     public override string Name => "Number Input Label";
 
     /// <summary>The minimum label value.</summary>
+    [UIDebug]
     public double Min = double.MinValue;
 
     /// <summary>The maximum label value.</summary>
+    [UIDebug]
     public double Max = double.MaxValue;
 
     /// <summary>Whether the label should be an integer instead of a decimal.</summary>
+    [UIDebug]
     public bool Integer;
 
     /// <summary>The format string to apply to the label on submission.</summary>
+    [UIDebug]
     public string Format;
 
     /// <summary>The character matcher for this number label type.</summary>
@@ -56,6 +60,7 @@ public class UINumberInputLabel : UIInputLabel
     public NumberLabelInternalData NumberLabelInternal = new();
 
     /// <summary>Gets or sets the decimal value of the label.</summary>
+    [UIDebug]
     public double Value
     {
         get => NumberLabelInternal.Value;
@@ -141,7 +146,4 @@ public class UINumberInputLabel : UIInputLabel
         NumberLabelInternal.Value = 0;
         return "0";
     }
-
-    /// <inheritdoc/>
-    public override List<string> GetDebugInfo() => [$"^7Value: ^3{Value}"];
 }

--- a/FGEGraphics/UISystem/UINumberSlider.cs
+++ b/FGEGraphics/UISystem/UINumberSlider.cs
@@ -24,27 +24,35 @@ public class UINumberSlider : UIElement
     public override string Name => "Number Slider";
 
     /// <summary>The minimum slider value.</summary>
+    [UIDebug]
     public double Min;
 
     /// <summary>The maximum slider value.</summary>
+    [UIDebug]
     public double Max;
 
     /// <summary>The default slider value.</summary>
+    [UIDebug]
     public double Default;
 
     /// <summary>The grid-snapping interval. Set to <c>0.0</c> or less for a gridless slider.</summary>
+    [UIDebug]
     public double Interval;
 
     /// <summary>Whether the slider should use integers instead of decimals.</summary>
+    [UIDebug]
     public bool Integer;
 
     /// <summary>The number of digits to round the slider value to, or <c>-1</c> for no rounding.</summary>
+    [UIDebug]
     public int Digits = -1;
 
     /// <summary>The current slider value.</summary>
+    [UIDebug]
     public double Value;
 
     /// <summary>The current slider progress (<c>0.0</c> to <c>1.0</c>).</summary>
+    [UIDebug]
     public double Progress => (Value - Min) / (Max - Min);
 
     /// <summary>The box placed at the current slider progress.</summary>

--- a/FGEGraphics/UISystem/UIParagraph.cs
+++ b/FGEGraphics/UISystem/UIParagraph.cs
@@ -34,6 +34,7 @@ public class UIParagraph(UILayout layout) : UIElement(UIStyle.Empty, layout)
 
     // TODO: getter/setter & recompute renderables like in UILabel
     /// <summary>The maximum width of this paragraph, or <c>-1</c> if the paragraph has no maximum width.</summary>
+    [UIDebug]
     public float MaxWidth = -1;
 
     /// <summary>Gets the text content of this paragraph.</summary>

--- a/FGEGraphics/UISystem/UIScrollGroup.cs
+++ b/FGEGraphics/UISystem/UIScrollGroup.cs
@@ -25,9 +25,11 @@ public class UIScrollGroup : UIElement
     public override string Name => "Scroll Group";
 
     /// <summary>The horizontal scroll axis.</summary>
+    [UIDebug]
     public Axis ScrollX;
 
     /// <summary>The vertical scroll axis.</summary>
+    [UIDebug]
     public Axis ScrollY;
 
     /// <summary>The scrollable scissor layer for child elements.</summary>
@@ -243,8 +245,8 @@ public class UIScrollGroup : UIElement
                 Value = MaxValue;
             }
         }
-    }
 
-    /// <inheritdoc/>
-    public override List<string> GetDebugInfo() => [$"^7Scroll: ^3({ScrollX.Value}, {ScrollY.Value}) ^&| ^7Max Scroll: ^3({ScrollX.MaxValue}, {ScrollY.MaxValue})"];
+        /// <inheritdoc/>
+        public override string ToString() => $"(Value: {Value}, Max: {MaxValue}, Speed: {ScrollSpeed}u/tick)";
+    }
 }

--- a/FGEGraphics/UISystem/UISelectionGroup.cs
+++ b/FGEGraphics/UISystem/UISelectionGroup.cs
@@ -22,9 +22,11 @@ public class UISelectionGroup(UILayout layout) : UIGroup(layout)
     public override string Name => "Selection Group";
 
     /// <summary>The minimum allowed number of selected elements, or <c>-1</c> for no lower bound.</summary>
+    [UIDebug]
     public int MinSelections = -1;
 
     /// <summary>The maximum allowed number of selected elements, or <c>-1</c> for no upper bound.</summary>
+    [UIDebug]
     public int MaxSelections
     {
         get => Internal.MaxSelections;
@@ -37,9 +39,11 @@ public class UISelectionGroup(UILayout layout) : UIGroup(layout)
     }
 
     /// <summary>Whether the oldest selected element should be dropped when the user selects a new element exceeding the <see cref="MaxSelections"/>.</summary>
+    [UIDebug]
     public bool IsCyclic = false;
 
     /// <summary>Whether non-selected elements are locked and cannot be selected.</summary>
+    [UIDebug]
     public bool IsLocked = false;
 
     /// <summary>The selectable elements managed by this group.</summary>

--- a/FGEGraphics/UISystem/UIToggleBox.cs
+++ b/FGEGraphics/UISystem/UIToggleBox.cs
@@ -26,6 +26,7 @@ public class UIToggleBox : UIBox
     public override string Name => "Toggle Box";
 
     /// <summary>Whether this box is toggled on.</summary>
+    [UIDebug]
     public bool Toggled = false;
 
     /// <summary>Fired when this box is toggled on or off.</summary>


### PR DESCRIPTION
## Overview 

- Split the debug overlay info into a simple 'list' view and a 'detailed' view.
- Added keybinds to control the UI debug overlay.
- Added a `UIDebug` attribute for fields and properties that automatically adds entries to the detailed debug overlay.
- Cleaned up the debug code in `ViewUI2D` and other miscellaneous fixes.

## New Keybinds

- `F4` to toggle debug mode.
- `ALT + Numpad 5` to toggle debug info.
- `ALT + Numpad 8 / 2` to scroll the debug info list up and down respectively.
- `ALT + SHIFT + Numpad 5` to switch between list view and detailed view in debug mode.
- `ALT + SHIFT + Numpad 8 / 2` to expand or contract the debug list view.

## Future Work

There's still many improvements to be made to the debug mode, but these ones are sufficient for resolving problems in the task at hand. I would like to properly document the keybinds somewhere, and I would like to make the info overlay prettier... somehow.

## Demos

### List View

<img width="1180" height="674" alt="image" src="https://github.com/user-attachments/assets/62a83838-5a82-49a5-b713-d91e50209e7d" />

### Detailed View

<img width="761" height="346" alt="image" src="https://github.com/user-attachments/assets/fb32d2b1-6304-463e-98a2-b35d7d62867a" />
